### PR TITLE
fix(FEC-7233): when parsing text tracks mark all as inactive

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -354,7 +354,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       for (let i = 0; i < textTracks.length; i++) {
         let settings = {
           kind: textTracks[i].kind ? textTracks[i].kind + 's' : "",
-          active: textTracks[i].active,
+          active: false,
           label: textTracks[i].label,
           language: textTracks[i].language,
           index: i

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -262,7 +262,7 @@ describe('DashAdapter: _getParsedTracks', () => {
         }
         if (track instanceof TextTrack) {
           track.kind.should.equal(textTracks[track.index].kind + 's');
-          track.active.should.equal(textTracks[track.index].active);
+          track.active.should.be.false;
           track.language.should.equal(textTracks[track.index].language);
           (track.label === textTracks[track.index].label).should.be.true;
         }
@@ -524,80 +524,80 @@ describe('DashAdapter: selectTextTrack', () => {
   });
 
   it('should not change the already selected text track', (done) => {
+    let eventCounter = 0;
     dashInstance.load().then(() => {
       dashInstance.addEventListener('texttrackchanged', () => {
-        eventIsFired = true;
+        eventCounter++;
+        activeTrack.active = true;
       });
-      let activeTrack = dashInstance._getParsedTextTracks().filter((track) => {
-        return track.active;
-      })[0];
-      let eventIsFired = false;
+      let activeTrack = dashInstance._getParsedTextTracks()[0];
+      dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack(activeTrack);
       activeTrack.language.should.be.equal(dashInstance._shaka.getTextTracks().filter((track) => {
         return track.active;
       })[0].language);
       setTimeout(() => {
-        eventIsFired.should.be.false;
+        eventCounter.should.equals(1);
         done();
       }, 1000)
     });
   });
 
   it('should not change the selected for video track given', (done) => {
+    let eventCounter = 0;
     dashInstance.load().then(() => {
       dashInstance.addEventListener('texttrackchanged', () => {
-        eventIsFired = true;
+        eventCounter++;
+        activeTrack.active = true;
       });
-      let activeTrack = dashInstance._getParsedTextTracks().filter((track) => {
-        return track.active;
-      })[0];
-      let eventIsFired = false;
+      let activeTrack = dashInstance._getParsedTextTracks()[0];
+      dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack(new VideoTrack({index: 0}));
       activeTrack.language.should.be.equal(dashInstance._shaka.getTextTracks().filter((track) => {
         return track.active;
       })[0].language);
       setTimeout(() => {
-        eventIsFired.should.be.false;
+        eventCounter.should.equals(1);
         done();
       }, 1000)
     });
   });
 
   it('should not change the selected for no text track given', (done) => {
+    let eventCounter = 0;
     dashInstance.load().then(() => {
       dashInstance.addEventListener('texttrackchanged', () => {
-        eventIsFired = true;
+        eventCounter++;
+        activeTrack.active = true;
       });
-      let activeTrack = dashInstance._getParsedTextTracks().filter((track) => {
-        return track.active;
-      })[0];
-      let eventIsFired = false;
+      let activeTrack = dashInstance._getParsedTextTracks()[0];
+      dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack();
       activeTrack.language.should.be.equal(dashInstance._shaka.getTextTracks().filter((track) => {
         return track.active;
       })[0].language);
       setTimeout(() => {
-        eventIsFired.should.be.false;
+        eventCounter.should.equals(1);
         done();
       }, 1000)
     });
   });
 
   it('should not change the selected for no subtitle or captions given', (done) => {
+    let eventCounter = 0;
     dashInstance.load().then(() => {
       dashInstance.addEventListener('texttrackchanged', () => {
-        eventIsFired = true;
+        eventCounter++;
+        activeTrack.active = true;
       });
-      let activeTrack = dashInstance._getParsedTextTracks().filter((track) => {
-        return track.active;
-      })[0];
-      let eventIsFired = false;
+      let activeTrack = dashInstance._getParsedTextTracks()[0];
+      dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack(new TextTrack({kind: 'metadata'}));
       activeTrack.language.should.be.equal(dashInstance._shaka.getTextTracks().filter((track) => {
         return track.active;
       })[0].language);
       setTimeout(() => {
-        eventIsFired.should.be.false;
+        eventCounter.should.equals(1);
         done();
       }, 1000)
     });


### PR DESCRIPTION
### Description of the Changes

To support playkit default tracks flow we start shaka text tracks as inactive instead of take the active track from shaka (in case no track defined in the configuration of shaka it will be the first track in the manifest).

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
