### PR TITLE
fix(FEC-7207): redundant buffering events

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -66,6 +66,20 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _buffering: boolean = false;
+  /**
+   * Whether 'waiting' event has been sent by the HTMLVideoElement
+   * @member {boolean} - _waitingSent
+   * @type {boolean}
+   * @private
+   */
+  _waitingSent: boolean = false;
+  /**
+   * Whether 'playing' event has been sent by the HTMLVideoElement
+   * @member {boolean} - _playingSent
+   * @type {boolean}
+   * @private
+   */
+  _playingSent: boolean = false;
 
   /**
    * Factory method to create media source adapter.
@@ -247,6 +261,8 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       DashAdapter._logger.debug('destroy');
       this._loadPromise = null;
       this._buffering = false;
+      this._waitingSent = false;
+      this._playingSent = false;
       if (DashAdapter._drmProtocol) {
         DashAdapter._drmProtocol.destroy();
         DashAdapter._drmProtocol = null;


### PR DESCRIPTION
### Description of the Changes

we listen to shaka `buffering` event and trigger `waiting/playing` accordingly.
sometimes the video element itself also triggers them and we get redundant events.
in this change we listen to the video element events, and only if them have not been triggered from the video tag we trigger the, from shaka   

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
