### PR TITLE
fix: clear event binding function references

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -59,7 +59,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @type {Object}
    * @private
    */
-  _adapterEventsBindings: Object = {};
+  _adapterEventsBindings: { [name: string]: Function } = {};
   /**
    * The load promise
    * @member {Promise<Object>} - _loadPromise
@@ -211,13 +211,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   }
 
 
-  _createAdapterFunctionBindings(): void{
-
-      this._adapterEventsBindings['error'] =  this._onError.bind(this);
-      this._adapterEventsBindings['adaption'] = this._onAdaptation.bind(this);
-      this._adapterEventsBindings['buffering'] = this._onBuffering.bind(this);
-      this._adapterEventsBindings['waiting'] = this._onWaiting.bind(this);
-      this._adapterEventsBindings['playing'] = this._onPlaying.bind(this);
+  _createAdapterFunctionBindings(): void {
+    this._adapterEventsBindings['error'] = (event) => this._onError(event);
+    this._adapterEventsBindings['adaption'] = () => this._onAdaptation();
+    this._adapterEventsBindings['buffering'] = (event) => this._onBuffering(event);
+    this._adapterEventsBindings['waiting'] = () => this._onWaiting();
+    this._adapterEventsBindings['playing'] = () => this._onPlaying();
   }
 
   /**
@@ -243,7 +242,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   _removeBindings(): void {
     this._shaka.removeEventListener('adaptation', this._adapterEventsBindings.adaption);
-    this._shaka.removeEventListener('error',  this._adapterEventsBindings.error);
+    this._shaka.removeEventListener('error', this._adapterEventsBindings.error);
     this._shaka.removeEventListener('buffering', this._adapterEventsBindings.buffering);
     //TODO use events enum when available
     this._videoElement.removeEventListener('waiting', this._adapterEventsBindings.waiting);
@@ -300,6 +299,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         this._removeBindings();
         return this._shaka.destroy();
       }
+      this._adapterEventsBindings = {};
     });
   }
 

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -7,15 +7,14 @@ import {Error} from 'playkit-js'
 import Widevine from './drm/widevine'
 import PlayReady from './drm/playready'
 
-
-type ShakaEventsType = { [event: string]: string };
+type ShakaEventType = { [event: string]: string };
 
 /**
  * Shaka events enum
  * @type {Object}
  * @const
  */
-const SHAKA_EVENTS: ShakaEventsType = {
+const ShakaEvent: ShakaEventType = {
   ERROR: 'error',
   ADAPTION: 'adaption',
   BUFFERING: 'buffering'
@@ -73,7 +72,13 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @type {Object}
    * @private
    */
-  _adapterEventsBindings: { [name: string]: Function } = {};
+  _adapterEventsBindings: { [name: string]: Function } = {
+    [ShakaEvent.ERROR]: (event) => this._onError(event),
+    [ShakaEvent.ADAPTION] : () => this._onAdaptation(),
+    [ShakaEvent.BUFFERING] : (event) => this._onBuffering(event),
+    [BaseMediaSourceAdapter.Html5Events.WAITING] : () => this._onWaiting(),
+    [BaseMediaSourceAdapter.Html5Events.PLAYING] : () => this._onPlaying()
+  };
   /**
    * The load promise
    * @member {Promise<Object>} - _loadPromise
@@ -195,7 +200,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   constructor(videoElement: HTMLVideoElement, source: Object, config: Object = {}) {
     DashAdapter._logger.debug('Creating adapter. Shaka version: ' + shaka.Player.version);
     super(videoElement, source, config);
-    this._createAdapterFunctionBindings();
   }
 
   /**
@@ -224,15 +228,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     }
   }
 
-
-  _createAdapterFunctionBindings(): void {
-    this._adapterEventsBindings[SHAKA_EVENTS.ERROR] = (event) => this._onError(event);
-    this._adapterEventsBindings[SHAKA_EVENTS.ADAPTION] = () => this._onAdaptation();
-    this._adapterEventsBindings[SHAKA_EVENTS.BUFFERING] = (event) => this._onBuffering(event);
-    this._adapterEventsBindings[BaseMediaSourceAdapter.Html5Events.WAITING] = () => this._onWaiting();
-    this._adapterEventsBindings[BaseMediaSourceAdapter.Html5Events.PLAYING] = () => this._onPlaying();
-  }
-
   /**
    * Add the required bindings to shaka.
    * @function _addBindings
@@ -240,9 +235,9 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    */
   _addBindings(): void {
-    this._shaka.addEventListener(SHAKA_EVENTS.ADAPTION, this._adapterEventsBindings.adaption);
-    this._shaka.addEventListener(SHAKA_EVENTS.ERROR, this._adapterEventsBindings.error);
-    this._shaka.addEventListener(SHAKA_EVENTS.BUFFERING, this._adapterEventsBindings.buffering);
+    this._shaka.addEventListener(ShakaEvent.ADAPTION, this._adapterEventsBindings.adaption);
+    this._shaka.addEventListener(ShakaEvent.ERROR, this._adapterEventsBindings.error);
+    this._shaka.addEventListener(ShakaEvent.BUFFERING, this._adapterEventsBindings.buffering);
     this._videoElement.addEventListener(BaseMediaSourceAdapter.Html5Events.WAITING, this._adapterEventsBindings.waiting);
     this._videoElement.addEventListener(BaseMediaSourceAdapter.Html5Events.PLAYING, this._adapterEventsBindings.playing);
   }
@@ -254,9 +249,9 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    */
   _removeBindings(): void {
-    this._shaka.removeEventListener(SHAKA_EVENTS.ADAPTION, this._adapterEventsBindings.adaption);
-    this._shaka.removeEventListener(SHAKA_EVENTS.ERROR, this._adapterEventsBindings.error);
-    this._shaka.removeEventListener(SHAKA_EVENTS.BUFFERING, this._adapterEventsBindings.buffering);
+    this._shaka.removeEventListener(ShakaEvent.ADAPTION, this._adapterEventsBindings.adaption);
+    this._shaka.removeEventListener(ShakaEvent.ERROR, this._adapterEventsBindings.error);
+    this._shaka.removeEventListener(ShakaEvent.BUFFERING, this._adapterEventsBindings.buffering);
     this._videoElement.removeEventListener(BaseMediaSourceAdapter.Html5Events.WAITING, this._adapterEventsBindings.waiting);
     this._videoElement.removeEventListener(BaseMediaSourceAdapter.Html5Events.PLAYING, this._adapterEventsBindings.playing);
   }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -54,6 +54,13 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   _shaka: any;
   /**
+   * an object containing all the events we bind and unbind to.
+   * @member {Object} - _adapterEventsBindings
+   * @type {Object}
+   * @private
+   */
+  _adapterEventsBindings: Object = {};
+  /**
    * The load promise
    * @member {Promise<Object>} - _loadPromise
    * @type {Promise<Object>}
@@ -174,6 +181,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   constructor(videoElement: HTMLVideoElement, source: Object, config: Object = {}) {
     DashAdapter._logger.debug('Creating adapter. Shaka version: ' + shaka.Player.version);
     super(videoElement, source, config);
+    this._createAdapterFunctionBindings();
   }
 
   /**
@@ -202,6 +210,16 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     }
   }
 
+
+  _createAdapterFunctionBindings(): void{
+
+      this._adapterEventsBindings['error'] =  this._onError.bind(this);
+      this._adapterEventsBindings['adaption'] = this._onAdaptation.bind(this);
+      this._adapterEventsBindings['buffering'] = this._onBuffering.bind(this);
+      this._adapterEventsBindings['waiting'] = this._onWaiting.bind(this);
+      this._adapterEventsBindings['playing'] = this._onPlaying.bind(this);
+  }
+
   /**
    * Add the required bindings to shaka.
    * @function _addBindings
@@ -209,12 +227,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    */
   _addBindings(): void {
-    this._shaka.addEventListener('adaptation', this._onAdaptation.bind(this));
-    this._shaka.addEventListener('error', this._onError.bind(this));
-    this._shaka.addEventListener('buffering', this._onBuffering.bind(this));
+    this._shaka.addEventListener('adaptation', this._adapterEventsBindings.adaption);
+    this._shaka.addEventListener('error', this._adapterEventsBindings.error);
+    this._shaka.addEventListener('buffering', this._adapterEventsBindings.buffering);
     //TODO use events enum when available
-    this._videoElement.addEventListener('waiting', this._onWaiting.bind(this));
-    this._videoElement.addEventListener('playing', this._onPlaying.bind(this));
+    this._videoElement.addEventListener('waiting', this._adapterEventsBindings.waiting);
+    this._videoElement.addEventListener('playing', this._adapterEventsBindings.playing);
   }
 
   /**
@@ -224,12 +242,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    */
   _removeBindings(): void {
-    this._shaka.removeEventListener('adaptation', this._onAdaptation);
-    this._shaka.removeEventListener('error', this._onError.bind(this));
-    this._shaka.removeEventListener('buffering', this._onBuffering.bind(this));
+    this._shaka.removeEventListener('adaptation', this._adapterEventsBindings.adaption);
+    this._shaka.removeEventListener('error',  this._adapterEventsBindings.error);
+    this._shaka.removeEventListener('buffering', this._adapterEventsBindings.buffering);
     //TODO use events enum when available
-    this._videoElement.removeEventListener('waiting', this._onWaiting.bind(this));
-    this._videoElement.removeEventListener('playing', this._onPlaying.bind(this));
+    this._videoElement.removeEventListener('waiting', this._adapterEventsBindings.waiting);
+    this._videoElement.removeEventListener('playing', this._adapterEventsBindings.playing);
   }
 
   /**

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -16,11 +16,9 @@ type ShakaEventsType = { [event: string]: string };
  * @const
  */
 const SHAKA_EVENTS: ShakaEventsType = {
-  ERROR: 'error' ,
+  ERROR: 'error',
   ADAPTION: 'adaption',
-  BUFFERING: 'buffering',
-  WAITING: 'waiting',
-  PLAYING: 'playing'
+  BUFFERING: 'buffering'
 };
 
 /**
@@ -231,8 +229,8 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._adapterEventsBindings[SHAKA_EVENTS.ERROR] = (event) => this._onError(event);
     this._adapterEventsBindings[SHAKA_EVENTS.ADAPTION] = () => this._onAdaptation();
     this._adapterEventsBindings[SHAKA_EVENTS.BUFFERING] = (event) => this._onBuffering(event);
-    this._adapterEventsBindings[SHAKA_EVENTS.WAITING] = () => this._onWaiting();
-    this._adapterEventsBindings[SHAKA_EVENTS.PLAYING] = () => this._onPlaying();
+    this._adapterEventsBindings[BaseMediaSourceAdapter.Html5Events.WAITING] = () => this._onWaiting();
+    this._adapterEventsBindings[BaseMediaSourceAdapter.Html5Events.PLAYING] = () => this._onPlaying();
   }
 
   /**
@@ -245,8 +243,8 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._shaka.addEventListener(SHAKA_EVENTS.ADAPTION, this._adapterEventsBindings.adaption);
     this._shaka.addEventListener(SHAKA_EVENTS.ERROR, this._adapterEventsBindings.error);
     this._shaka.addEventListener(SHAKA_EVENTS.BUFFERING, this._adapterEventsBindings.buffering);
-    this._videoElement.addEventListener(SHAKA_EVENTS.WAITING, this._adapterEventsBindings.waiting);
-    this._videoElement.addEventListener(SHAKA_EVENTS.PLAYING, this._adapterEventsBindings.playing);
+    this._videoElement.addEventListener(BaseMediaSourceAdapter.Html5Events.WAITING, this._adapterEventsBindings.waiting);
+    this._videoElement.addEventListener(BaseMediaSourceAdapter.Html5Events.PLAYING, this._adapterEventsBindings.playing);
   }
 
   /**
@@ -259,8 +257,8 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._shaka.removeEventListener(SHAKA_EVENTS.ADAPTION, this._adapterEventsBindings.adaption);
     this._shaka.removeEventListener(SHAKA_EVENTS.ERROR, this._adapterEventsBindings.error);
     this._shaka.removeEventListener(SHAKA_EVENTS.BUFFERING, this._adapterEventsBindings.buffering);
-    this._videoElement.removeEventListener(SHAKA_EVENTS.WAITING, this._adapterEventsBindings.waiting);
-    this._videoElement.removeEventListener(SHAKA_EVENTS.PLAYING, this._adapterEventsBindings.playing);
+    this._videoElement.removeEventListener(BaseMediaSourceAdapter.Html5Events.WAITING, this._adapterEventsBindings.waiting);
+    this._videoElement.removeEventListener(BaseMediaSourceAdapter.Html5Events.PLAYING, this._adapterEventsBindings.playing);
   }
 
   /**

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -7,6 +7,22 @@ import {Error} from 'playkit-js'
 import Widevine from './drm/widevine'
 import PlayReady from './drm/playready'
 
+
+type ShakaEventsType = { [event: string]: string };
+
+/**
+ * Shaka events enum
+ * @type {Object}
+ * @const
+ */
+const SHAKA_EVENTS: ShakaEventsType = {
+  ERROR: 'error' ,
+  ADAPTION: 'adaption',
+  BUFFERING: 'buffering',
+  WAITING: 'waiting',
+  PLAYING: 'playing'
+};
+
 /**
  * Adapter of shaka lib for dash content
  * @classdesc
@@ -212,11 +228,11 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
 
 
   _createAdapterFunctionBindings(): void {
-    this._adapterEventsBindings['error'] = (event) => this._onError(event);
-    this._adapterEventsBindings['adaption'] = () => this._onAdaptation();
-    this._adapterEventsBindings['buffering'] = (event) => this._onBuffering(event);
-    this._adapterEventsBindings['waiting'] = () => this._onWaiting();
-    this._adapterEventsBindings['playing'] = () => this._onPlaying();
+    this._adapterEventsBindings[SHAKA_EVENTS.ERROR] = (event) => this._onError(event);
+    this._adapterEventsBindings[SHAKA_EVENTS.ADAPTION] = () => this._onAdaptation();
+    this._adapterEventsBindings[SHAKA_EVENTS.BUFFERING] = (event) => this._onBuffering(event);
+    this._adapterEventsBindings[SHAKA_EVENTS.WAITING] = () => this._onWaiting();
+    this._adapterEventsBindings[SHAKA_EVENTS.PLAYING] = () => this._onPlaying();
   }
 
   /**
@@ -226,12 +242,11 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    */
   _addBindings(): void {
-    this._shaka.addEventListener('adaptation', this._adapterEventsBindings.adaption);
-    this._shaka.addEventListener('error', this._adapterEventsBindings.error);
-    this._shaka.addEventListener('buffering', this._adapterEventsBindings.buffering);
-    //TODO use events enum when available
-    this._videoElement.addEventListener('waiting', this._adapterEventsBindings.waiting);
-    this._videoElement.addEventListener('playing', this._adapterEventsBindings.playing);
+    this._shaka.addEventListener(SHAKA_EVENTS.ADAPTION, this._adapterEventsBindings.adaption);
+    this._shaka.addEventListener(SHAKA_EVENTS.ERROR, this._adapterEventsBindings.error);
+    this._shaka.addEventListener(SHAKA_EVENTS.BUFFERING, this._adapterEventsBindings.buffering);
+    this._videoElement.addEventListener(SHAKA_EVENTS.WAITING, this._adapterEventsBindings.waiting);
+    this._videoElement.addEventListener(SHAKA_EVENTS.PLAYING, this._adapterEventsBindings.playing);
   }
 
   /**
@@ -241,12 +256,11 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    */
   _removeBindings(): void {
-    this._shaka.removeEventListener('adaptation', this._adapterEventsBindings.adaption);
-    this._shaka.removeEventListener('error', this._adapterEventsBindings.error);
-    this._shaka.removeEventListener('buffering', this._adapterEventsBindings.buffering);
-    //TODO use events enum when available
-    this._videoElement.removeEventListener('waiting', this._adapterEventsBindings.waiting);
-    this._videoElement.removeEventListener('playing', this._adapterEventsBindings.playing);
+    this._shaka.removeEventListener(SHAKA_EVENTS.ADAPTION, this._adapterEventsBindings.adaption);
+    this._shaka.removeEventListener(SHAKA_EVENTS.ERROR, this._adapterEventsBindings.error);
+    this._shaka.removeEventListener(SHAKA_EVENTS.BUFFERING, this._adapterEventsBindings.buffering);
+    this._videoElement.removeEventListener(SHAKA_EVENTS.WAITING, this._adapterEventsBindings.waiting);
+    this._videoElement.removeEventListener(SHAKA_EVENTS.PLAYING, this._adapterEventsBindings.playing);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Created an object to hold all the event handlers, so we can unbind it properly. 
Today we don't really unbind the handler because it's a new handler and not a reference to the previous one.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
