### PR TITLE
feat(FEC-7330): enable setting custom track labels by app

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -387,7 +387,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
           width: videoTracks[i].width,
           height: videoTracks[i].height,
           active: videoTracks[i].active,
-          label: videoTracks[i].label,
           index: i
         };
         parsedTracks.push(new VideoTrack(settings));

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -261,7 +261,6 @@ describe('DashAdapter: _getParsedTracks', () => {
           track.id.should.equal(videoTracks[track.index].id);
           track.active.should.equal(videoTracks[track.index].active);
           track.bandwidth.should.equal(videoTracks[track.index].bandwidth);
-          (track.label === videoTracks[track.index].label).should.be.true;
         }
         if (track instanceof AudioTrack) {
           track.id.should.equal(audioTracks[track.index].id);


### PR DESCRIPTION
### Description of the Changes

Removed the label in the video track as we set it in the VideoTrack.js in core

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
