### PR TITLE
fix(FEC-7935): fix text selection logic

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -129,6 +129,9 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     if (Utils.Object.hasPropertyPath(config, 'playback.options.html5.dash')) {
       dashConfig = config.playback.options.html5.dash;
     }
+    if (Utils.Object.hasPropertyPath(config, 'playback.useNativeTextTrack')) {
+      dashConfig.textTrackVisibile = Utils.Object.getPropertyPath(config, 'playback.useNativeTextTrack');
+    }
     return new this(videoElement, source, dashConfig);
   }
 
@@ -227,7 +230,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._shaka = new shaka.Player(this._videoElement);
     this._maybeSetDrmConfig();
     this._shaka.configure(this._config);
-    this._shaka.setTextTrackVisibility(false);
     this._addBindings();
   }
 
@@ -493,6 +495,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   selectTextTrack(textTrack: TextTrack): void {
     if (this._shaka && (textTrack instanceof TextTrack) && !textTrack.active && (textTrack.kind === 'subtitles' || textTrack.kind === 'captions')) {
+      this._shaka.setTextTrackVisibility(this._config.textTrackVisibile);
       this._shaka.selectTextLanguage(textTrack.language);
       this._onTrackChanged(textTrack);
     }

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -227,6 +227,8 @@ describe('DashAdapter: destroy', () => {
         dashInstance._buffering.should.be.false;
         done();
       });
+    }).catch(e => {
+      done(e);
     });
   });
 });
@@ -309,11 +311,12 @@ describe('DashAdapter: selectVideoTrack', () => {
 
   it('should select a new video track', (done) => {
     let inactiveTrack;
+    let error;
     let onVideoTrackChanged = (event) => {
       dashInstance.removeEventListener('videotrackchanged', onVideoTrackChanged);
       try {
         event.payload.selectedVideoTrack.id.should.be.equal(inactiveTrack.id);
-        done();
+        done(error);
       } catch (e) {
         done(e);
       }
@@ -329,9 +332,8 @@ describe('DashAdapter: selectVideoTrack', () => {
       })[0];
       try {
         activeTrack.id.should.be.equal(inactiveTrack.id);
-        done();
       } catch (e) {
-        done(e);
+        error = e;
       }
     });
   });
@@ -673,10 +675,14 @@ describe('DashAdapter: enableAdaptiveBitrate', () => {
     let mode = 'manual';
     let counter = 0;
     dashInstance.addEventListener('abrmodechanged', (event) => {
-      event.payload.mode.should.equal(mode);
-      counter++;
-      if (counter === 3) {
-        done();
+      try {
+        event.payload.mode.should.equal(mode);
+        counter++;
+        if (counter === 3) {
+          done();
+        }
+      } catch (e){
+        done(e);
       }
     });
     dashInstance.load().then(() => {

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -666,7 +666,7 @@ describe('DashAdapter: enableAdaptiveBitrate', () => {
       dashInstance._shaka.getConfiguration().abr.enabled.should.be.true;
       dashInstance.isAdaptiveBitrateEnabled().should.be.true;
       done();
-    }).catch((e)=> {
+    }).catch((e) => {
       done(e)
     });
   });
@@ -681,7 +681,7 @@ describe('DashAdapter: enableAdaptiveBitrate', () => {
         if (counter === 3) {
           done();
         }
-      } catch (e){
+      } catch (e) {
         done(e);
       }
     });
@@ -799,11 +799,11 @@ describe('DashAdapter: seekToLiveEdge', () => {
     dashInstance = DashAdapter.createAdapter(video, liveSource, config);
     dashInstance.load().then(() => {
       video.currentTime = dashInstance._shaka.seekRange().start;
-      ((dashInstance._shaka.seekRange().end - video.currentTime) >= 30).should.be.true;
+      ((dashInstance._shaka.seekRange().end - video.currentTime) >= 20).should.be.true;
       dashInstance.seekToLiveEdge();
       ((dashInstance._shaka.seekRange().end - video.currentTime) <= 1).should.be.true;
       done();
-    }).catch((e)=> {
+    }).catch((e) => {
       done(e)
     });
   });
@@ -816,7 +816,7 @@ describe('DashAdapter: seekToLiveEdge', () => {
       dashInstance.seekToLiveEdge();
       ((dashInstance._shaka.seekRange().end - video.currentTime) < 1).should.be.true;
       done();
-    }).catch((e)=> {
+    }).catch((e) => {
       done(e)
     });
   });

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -179,6 +179,8 @@ describe('DashAdapter: load', () => {
     dashInstance = DashAdapter.createAdapter(video, vodSource, config);
     dashInstance.load().then(() => {
       done();
+    }).catch(e => {
+      done(e)
     });
   });
 
@@ -309,8 +311,12 @@ describe('DashAdapter: selectVideoTrack', () => {
     let inactiveTrack;
     let onVideoTrackChanged = (event) => {
       dashInstance.removeEventListener('videotrackchanged', onVideoTrackChanged);
-      event.payload.selectedVideoTrack.id.should.be.equal(inactiveTrack.id);
-      done();
+      try {
+        event.payload.selectedVideoTrack.id.should.be.equal(inactiveTrack.id);
+        done();
+      } catch (e) {
+        done(e);
+      }
     };
     dashInstance.load().then(() => {
       dashInstance.addEventListener('videotrackchanged', onVideoTrackChanged);
@@ -453,8 +459,12 @@ describe('DashAdapter: selectAudioTrack', () => {
         return track.active;
       })[0].id);
       setTimeout(() => {
-        eventIsFired.should.be.false;
-        done();
+        try {
+          eventIsFired.should.be.false;
+          done();
+        } catch (e) {
+          done(e);
+        }
       }, 1000)
     });
   });
@@ -551,8 +561,12 @@ describe('DashAdapter: selectTextTrack', () => {
         return track.active;
       })[0].language);
       setTimeout(() => {
-        eventCounter.should.equals(1);
-        done();
+        try {
+          eventCounter.should.equals(1);
+          done();
+        } catch (e) {
+          done(e);
+        }
       }, 1000)
     });
   });
@@ -638,13 +652,16 @@ describe('DashAdapter: enableAdaptiveBitrate', () => {
     TestUtils.removeVideoElementsFromTestPage();
   });
 
-  it('should enable ABR', () => {
+  it('should enable ABR', (done) => {
     dashInstance.load().then(() => {
       dashInstance._shaka.getConfiguration().abr.enabled.should.be.false;
       dashInstance.enableAdaptiveBitrate();
       dashInstance._shaka.getConfiguration().abr.enabled.should.be.true;
       dashInstance.isAdaptiveBitrateEnabled().should.be.true;
+      done();
     });
+  }).catch((e)=> {
+    done(e)
   });
 
   it('should fire abr mode changed event', (done) => {
@@ -693,6 +710,8 @@ describe('DashAdapter: isLive', () => {
     dashInstance.load().then(() => {
       dashInstance.isLive().should.be.false;
       done();
+    }).catch(e => {
+      done(e);
     });
   });
 
@@ -773,6 +792,8 @@ describe('DashAdapter: seekToLiveEdge', () => {
       dashInstance.seekToLiveEdge();
       ((dashInstance._shaka.seekRange().end - video.currentTime) <= 1).should.be.true;
       done();
+    }).catch((e)=> {
+      done(e)
     });
   });
 
@@ -784,6 +805,8 @@ describe('DashAdapter: seekToLiveEdge', () => {
       dashInstance.seekToLiveEdge();
       ((dashInstance._shaka.seekRange().end - video.currentTime) < 1).should.be.true;
       done();
+    }).catch((e)=> {
+      done(e)
     });
   });
 });

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -327,7 +327,12 @@ describe('DashAdapter: selectVideoTrack', () => {
       let activeTrack = dashInstance._getVideoTracks().filter((track) => {
         return track.active;
       })[0];
-      activeTrack.id.should.be.equal(inactiveTrack.id);
+      try {
+        activeTrack.id.should.be.equal(inactiveTrack.id);
+        done();
+      } catch (e) {
+        done(e);
+      }
     });
   });
 

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -659,9 +659,9 @@ describe('DashAdapter: enableAdaptiveBitrate', () => {
       dashInstance._shaka.getConfiguration().abr.enabled.should.be.true;
       dashInstance.isAdaptiveBitrateEnabled().should.be.true;
       done();
+    }).catch((e)=> {
+      done(e)
     });
-  }).catch((e)=> {
-    done(e)
   });
 
   it('should fire abr mode changed event', (done) => {


### PR DESCRIPTION
### Description of the Changes

use shaka `setTextTrackVisibility` to set text track display mode according to `useNativeTextTrack` config flag.
This change is part of https://github.com/kaltura/playkit-js-hls/pull/65/ and https://github.com/kaltura/playkit-js/pull/263 - removing the overhead of handling in playkit-js is possible by using the Shaka APIs to set track visibility.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
