### PR TITLE
fix(FEC-8396): media source adapters default config overrides the player supplied config

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -213,7 +213,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         return new TextDisplayer(videoEl);
       }.bind(null, this._videoElement)
     };
-    this._config = Utils.Object.mergeDeep(textDisplayerConfig, this._config, DefaultConfig);
+    this._config = Utils.Object.mergeDeep(textDisplayerConfig, DefaultConfig, this._config);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

The merge order for the config gave default config precedence over the application supplied config

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
