### PR TITLE
fix(FEC-7590): filter Shaka audio tracks by language and not bitrate

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -347,16 +347,16 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   _getAudioTracks(): Array<Object> {
     const variantTracks = this._shaka.getVariantTracks();
-    const activeVariantTrack = variantTracks.filter(variantTrack => {
-      return variantTrack.active;
-    })[0];
-    const matchingVariantTracks = variantTracks.filter(variantTrack => {
-      return variantTrack.videoId === activeVariantTrack.videoId;
-    });
     let audioTracks = this._shaka.getAudioLanguagesAndRoles();
     audioTracks.forEach(track => {
-      const sameLangVariant = matchingVariantTracks.find(variant => variant.language === track.language);
-      track.label = sameLangVariant.label;
+      track.id = '';
+      variantTracks.forEach(variant => {
+        if (variant.language === track.language) {
+          track.id += variant.id;
+          track.label = variant.label;
+          track.active = variant.active;
+        }
+      });
     });
     return audioTracks;
   }
@@ -414,6 +414,8 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     if (audioTracks) {
       for (let i = 0; i < audioTracks.length; i++) {
         let settings = {
+          id: audioTracks[i].id,
+          active: audioTracks[i].active,
           label: audioTracks[i].label,
           language: audioTracks[i].language,
           index: i

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -342,16 +342,21 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   /**
    * Get the original audio tracks
    * @function _getAudioTracks
-   * @returns {Array<Object>} - The original audio tracks
+   * @returns {Array<Object>} - Array of objects with unique language and label.
    * @private
    */
   _getAudioTracks(): Array<Object> {
-    let variantTracks = this._shaka.getVariantTracks();
-    let activeVariantTrack = variantTracks.filter(variantTrack => {
+    const variantTracks = this._shaka.getVariantTracks();
+    const activeVariantTrack = variantTracks.filter(variantTrack => {
       return variantTrack.active;
     })[0];
-    let audioTracks = variantTracks.filter(variantTrack => {
+    const matchingVariantTracks = variantTracks.filter(variantTrack => {
       return variantTrack.videoId === activeVariantTrack.videoId;
+    });
+    let audioTracks = this._shaka.getAudioLanguagesAndRoles();
+    audioTracks.forEach(track => {
+      const sameLangVariant = matchingVariantTracks.find(variant => variant.language === track.language);
+      track.label = sameLangVariant.label;
     });
     return audioTracks;
   }
@@ -409,8 +414,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     if (audioTracks) {
       for (let i = 0; i < audioTracks.length; i++) {
         let settings = {
-          id: audioTracks[i].id,
-          active: audioTracks[i].active,
           label: audioTracks[i].label,
           language: audioTracks[i].language,
           index: i

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -349,14 +349,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     const variantTracks = this._shaka.getVariantTracks();
     let audioTracks = this._shaka.getAudioLanguagesAndRoles();
     audioTracks.forEach(track => {
-      track.id = '';
-      variantTracks.forEach(variant => {
-        if (variant.language === track.language) {
-          track.id += variant.id;
-          track.label = variant.label;
-          track.active = variant.active;
-        }
-      });
+      const sameLangAudioVariants = variantTracks.filter(vt => vt.language === track.language);
+      const id = sameLangAudioVariants.map(variant => variant.id).join('_');
+      const active = sameLangAudioVariants.some(variant => variant.active);
+      track.id = id;
+      track.label = sameLangAudioVariants[0].label;
+      track.active = active;
     });
     return audioTracks;
   }

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -230,7 +230,7 @@ describe('DashAdapter: destroy', () => {
         dashInstance.destroy().then(() => {
           (!dashInstance._loadPromise).should.be.true;
           (!dashInstance._sourceObj).should.be.true;
-          (!dashInstance._config).should.be.true;
+          Object.keys(dashInstance._config).length.should.equal(0);
           dashInstance._buffering.should.be.false;
           done();
         });
@@ -275,8 +275,6 @@ describe('DashAdapter: _getParsedTracks', () => {
           track.bandwidth.should.equal(videoTracks[track.index].bandwidth);
         }
         if (track instanceof AudioTrack) {
-          track.id.should.equal(audioTracks[track.index].id);
-          track.active.should.equal(audioTracks[track.index].active);
           track.language.should.equal(audioTracks[track.index].language);
           (track.label === audioTracks[track.index].label).should.be.true;
         }
@@ -458,7 +456,7 @@ describe('DashAdapter: selectAudioTrack', () => {
   it('should select a new audio track', done => {
     dashInstance.load().then(() => {
       dashInstance.addEventListener('audiotrackchanged', event => {
-        event.payload.selectedAudioTrack.id.should.be.equal(inactiveTrack.id);
+        event.payload.selectedAudioTrack.language.should.be.equal(inactiveTrack.language);
         done();
       });
       let inactiveTrack = dashInstance._getParsedAudioTracks().filter(track => {
@@ -473,15 +471,16 @@ describe('DashAdapter: selectAudioTrack', () => {
       dashInstance.addEventListener('audiotrackchanged', () => {
         eventIsFired = true;
       });
-      let activeTrack = dashInstance._getParsedAudioTracks().filter(track => {
-        return track.active;
+      let englishTrack = dashInstance._getParsedAudioTracks().filter(track => {
+        return track.language === 'en';
       })[0];
       let eventIsFired = false;
-      dashInstance.selectAudioTrack(activeTrack);
-      activeTrack.id.should.be.equal(
+      englishTrack.active = true;
+      dashInstance.selectAudioTrack(englishTrack);
+      englishTrack.language.should.be.equal(
         dashInstance._shaka.getVariantTracks().filter(track => {
-          return track.active;
-        })[0].id
+          return track.language === 'en';
+        })[0].language
       );
       setTimeout(() => {
         try {
@@ -499,15 +498,15 @@ describe('DashAdapter: selectAudioTrack', () => {
       dashInstance.addEventListener('audiotrackchanged', () => {
         eventIsFired = true;
       });
-      let activeTrack = dashInstance._getParsedAudioTracks().filter(track => {
-        return track.active;
+      let englishTrack = dashInstance._getParsedAudioTracks().filter(track => {
+        return track.language === 'en';
       })[0];
       let eventIsFired = false;
       dashInstance.selectAudioTrack(new VideoTrack({index: 0}));
-      activeTrack.id.should.be.equal(
+      englishTrack.language.should.be.equal(
         dashInstance._shaka.getVariantTracks().filter(track => {
-          return track.active;
-        })[0].id
+          return track.language === 'en';
+        })[0].language
       );
       setTimeout(() => {
         eventIsFired.should.be.false;
@@ -521,15 +520,15 @@ describe('DashAdapter: selectAudioTrack', () => {
       dashInstance.addEventListener('audiotrackchanged', () => {
         eventIsFired = true;
       });
-      let activeTrack = dashInstance._getParsedAudioTracks().filter(track => {
-        return track.active;
+      let englishTrack = dashInstance._getParsedAudioTracks().filter(track => {
+        return track.language === 'en';
       })[0];
       let eventIsFired = false;
       dashInstance.selectAudioTrack();
-      activeTrack.id.should.be.equal(
+      englishTrack.language.should.be.equal(
         dashInstance._shaka.getVariantTracks().filter(track => {
-          return track.active;
-        })[0].id
+          return track.language === 'en';
+        })[0].language
       );
       setTimeout(() => {
         eventIsFired.should.be.false;


### PR DESCRIPTION
### Description of the Changes

creating an audio track array of unique languages
no need to ID and setting the active, it is set by the player.
using getAudioLanguagesAndRoles() to get the list of languages from shaka.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
