### PR TITLE
feat(FEC-8553): add ability to force redirect kaltura playManifest urls

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
     client: {
       mocha: {
         reporter: 'html',
-        timeout: 5000
+        timeout: 10000
       }
     }
   };

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -282,7 +282,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     const callback = this._config.redirectExternalStreamsHandler;
     return new Promise(resolve => {
       if (!shouldRedirect) {
-        resolve(url);
+        return resolve(url);
       }
       Utils.Http.jsonp(url, callback, {
         timeout: timeout

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -348,7 +348,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
           const shakaStartTime = startTime && startTime > -1 ? startTime : undefined;
           this._maybeGetRedirectedUrl(this._sourceObj.url)
             .then(url => {
-              this._shaka.load(url, shakaStartTime);
+              return this._shaka.load(url, shakaStartTime);
             })
             .then(() => {
               let data = {tracks: this._getParsedTracks()};

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -125,14 +125,20 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @static
    */
   static createAdapter(videoElement: HTMLVideoElement, source: PKMediaSourceObject, config: Object): IMediaSourceAdapter {
-    let dashConfig = {};
+    let adapterConfig = {};
     if (Utils.Object.hasPropertyPath(config, 'playback.options.html5.dash')) {
-      dashConfig = config.playback.options.html5.dash;
+      adapterConfig.shakaConfig = config.playback.options.html5.dash;
     }
     if (Utils.Object.hasPropertyPath(config, 'playback.useNativeTextTrack')) {
-      dashConfig.textTrackVisibile = Utils.Object.getPropertyPath(config, 'playback.useNativeTextTrack');
+      adapterConfig.textTrackVisibile = Utils.Object.getPropertyPath(config, 'playback.useNativeTextTrack');
     }
-    return new this(videoElement, source, dashConfig);
+    if (Utils.Object.hasPropertyPath(config, 'sources.options')) {
+      const options = config.sources.options;
+      adapterConfig.forceRedirectExternalStreams = options.forceRedirectExternalStreams;
+      adapterConfig.redirectExternalStreamsHandler = options.redirectExternalStreamsHandler;
+      adapterConfig.redirectExternalStreamsTimeout = options.redirectExternalStreamsTimeout;
+    }
+    return new this(videoElement, source, adapterConfig);
   }
 
   /**
@@ -260,8 +266,32 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     shaka.polyfill.installAll();
     this._shaka = new shaka.Player(this._videoElement);
     this._maybeSetDrmConfig();
-    this._shaka.configure(this._config);
+    this._shaka.configure(this._config.shakaConfig);
     this._addBindings();
+  }
+
+  /**
+   * get the redirected URL
+   * @param {string} url - The url to check for redirection
+   * @returns {Promise<string>} - the resolved url
+   * @private
+   */
+  _maybeGetRedirectedUrl(url: string): Promise<string> {
+    const shouldRedirect = this._config.forceRedirectExternalStreams;
+    const timeout = this._config.redirectExternalStreamsTimeout;
+    const callback = this._config.redirectExternalStreamsHandler;
+    return new Promise(resolve => {
+      if (!shouldRedirect) {
+        resolve(url);
+      }
+      Utils.Http.jsonp(url, callback, {
+        timeout: timeout
+      })
+        .then(uri => {
+          resolve(uri);
+        })
+        .catch(() => resolve(url));
+    });
   }
 
   /**
@@ -316,8 +346,10 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         if (this._sourceObj && this._sourceObj.url) {
           this._trigger(EventType.ABR_MODE_CHANGED, {mode: this.isAdaptiveBitrateEnabled() ? 'auto' : 'manual'});
           const shakaStartTime = startTime && startTime > -1 ? startTime : undefined;
-          this._shaka
-            .load(this._sourceObj.url, shakaStartTime)
+          this._maybeGetRedirectedUrl(this._sourceObj.url)
+            .then(url => {
+              this._shaka.load(url, shakaStartTime);
+            })
             .then(() => {
               let data = {tracks: this._getParsedTracks()};
               DashAdapter._logger.debug('The source has been loaded successfully');

--- a/src/default-config.json
+++ b/src/default-config.json
@@ -1,5 +1,8 @@
 {
-  "streaming": {
-    "ignoreTextStreamFailures": true
-  }
+  "shakaConfig": {
+    "streaming": {
+      "ignoreTextStreamFailures": true
+    }
+  },
+  "forceRedirectExternalStreams": false
 }


### PR DESCRIPTION
### Description of the Changes

Use kaltura JSONP service to allow getting the redirected playManifest URL directly.
This is to avoid issues with UA that consider CORS 302 responses as unsecured(IE11)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
