### PR TITLE
fix(FEC-8684): IE11 live dash playback is stuck

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -623,7 +623,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   seekToLiveEdge(): void {
-    if (this._shaka) {
+    if (this._shaka && this._loadPromise) {
       this._loadPromise.then(() => {
         this._videoElement.currentTime = this._shaka.seekRange().end;
       });

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -624,7 +624,9 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   seekToLiveEdge(): void {
     if (this._shaka) {
-      this._videoElement.currentTime = this._shaka.seekRange().end;
+      this._loadPromise.then(() => {
+        this._videoElement.currentTime = this._shaka.seekRange().end;
+      });
     }
   }
 

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -953,10 +953,12 @@ describe('DashAdapter: seekToLiveEdge', () => {
           video.currentTime = dashInstance._shaka.seekRange().start;
           const initialTimeShift = dashInstance._shaka.seekRange().end - video.currentTime;
           dashInstance.seekToLiveEdge();
-          const timeShift = dashInstance._shaka.seekRange().end - video.currentTime;
-          timeShift.should.be.lessThan(3);
-          timeShift.should.be.lessThan(initialTimeShift);
-          done();
+          dashInstance._loadPromise.then(() => {
+            const timeShift = dashInstance._shaka.seekRange().end - video.currentTime;
+            timeShift.should.be.lessThan(3);
+            timeShift.should.be.lessThan(initialTimeShift);
+            done();
+          });
         } catch (e) {
           done(e);
         }


### PR DESCRIPTION
### Description of the Changes

Cannot assign `videoElement.currentTime` before `loadedmetadata` is fired.

Used the `_loadPromise` as a flag.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
