### PR TITLE
fix(FEC-8711): live in IE has a small jump in the stream after a second

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -344,9 +344,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   load(startTime: ?number): Promise<Object> {
     if (!this._loadPromise) {
       this._init();
-      this._metadataLoadedPromise = new Promise(resolve => {
-        this._videoElement.addEventListener(EventType.LOADED_METADATA, () => resolve());
-      });
       this._loadPromise = new Promise((resolve, reject) => {
         if (this._sourceObj && this._sourceObj.url) {
           this._trigger(EventType.ABR_MODE_CHANGED, {mode: this.isAdaptiveBitrateEnabled() ? 'auto' : 'manual'});
@@ -379,7 +376,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     return super.destroy().then(() => {
       DashAdapter._logger.debug('destroy');
       this._loadPromise = null;
-      this._metadataLoadedPromise = null;
       this._buffering = false;
       this._waitingSent = false;
       this._playingSent = false;
@@ -627,10 +623,8 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   seekToLiveEdge(): void {
-    if (this._shaka && this._loadPromise) {
-      this._metadataLoadedPromise.then(() => {
-        this._videoElement.currentTime = this._shaka.seekRange().end;
-      });
+    if (this._shaka && this._videoElement.readyState > 0) {
+      this._videoElement.currentTime = this._shaka.seekRange().end;
     }
   }
 

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -344,6 +344,9 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   load(startTime: ?number): Promise<Object> {
     if (!this._loadPromise) {
       this._init();
+      this._metadataLoadedPromise = new Promise(resolve => {
+        this._videoElement.addEventListener(EventType.LOADED_METADATA, () => resolve());
+      });
       this._loadPromise = new Promise((resolve, reject) => {
         if (this._sourceObj && this._sourceObj.url) {
           this._trigger(EventType.ABR_MODE_CHANGED, {mode: this.isAdaptiveBitrateEnabled() ? 'auto' : 'manual'});
@@ -376,6 +379,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     return super.destroy().then(() => {
       DashAdapter._logger.debug('destroy');
       this._loadPromise = null;
+      this._metadataLoadedPromise = null;
       this._buffering = false;
       this._waitingSent = false;
       this._playingSent = false;
@@ -624,7 +628,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   seekToLiveEdge(): void {
     if (this._shaka && this._loadPromise) {
-      this._loadPromise.then(() => {
+      this._metadataLoadedPromise.then(() => {
         this._videoElement.currentTime = this._shaka.seekRange().end;
       });
     }

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -950,10 +950,10 @@ describe('DashAdapter: seekToLiveEdge', () => {
       .load()
       .then(() => {
         try {
-          video.currentTime = dashInstance._shaka.seekRange().start;
-          const initialTimeShift = dashInstance._shaka.seekRange().end - video.currentTime;
-          dashInstance.seekToLiveEdge();
-          dashInstance._loadPromise.then(() => {
+          video.play().then(() => {
+            video.currentTime = dashInstance._shaka.seekRange().start;
+            const initialTimeShift = dashInstance._shaka.seekRange().end - video.currentTime;
+            dashInstance.seekToLiveEdge();
             const timeShift = dashInstance._shaka.seekRange().end - video.currentTime;
             timeShift.should.be.lessThan(3);
             timeShift.should.be.lessThan(initialTimeShift);


### PR DESCRIPTION
### Description of the Changes

Instead of waiting for shaka to load (which is done after load event) letting dash player wait for metadata loaded event.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
