### PR TITLE
fix(FEC-9262): playback doesn't return to start after playback with ads in LG TV

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -415,7 +415,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    */
   attachMediaSource(playbackEnded: boolean): void {
-    if (!this._hls) {
+    if (!this._shaka) {
       if (this._videoElement && this._videoElement.src) {
         Utils.Dom.setAttribute(this._videoElement, 'src', '');
         Utils.Dom.removeAttribute(this._videoElement, 'src');
@@ -426,7 +426,8 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         this._lastTimeDetach = NaN;
       };
       if (!isNaN(this._lastTimeDetach)) {
-        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach(playbackEnded ? 0 : this._lastTimeDetach));
+        const seekTo = playbackEnded ? 0 : this._lastTimeDetach;
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach(seekTo));
       }
     }
   }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -418,22 +418,24 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   /**
    * attach media - return the media source to handle the video tag
    * @public
-   * @param {boolean} playbackEnded playback ended after ads and media
    * @returns {void}
    */
-  attachMediaSource(playbackEnded: boolean): void {
+  attachMediaSource(): void {
     if (!this._isMediaAttached) {
       if (this._videoElement && this._videoElement.src) {
         Utils.Dom.setAttribute(this._videoElement, 'src', '');
         Utils.Dom.removeAttribute(this._videoElement, 'src');
       }
-      const _seekAfterDetach = seekTo => {
-        this.currentTime = seekTo;
+      const _seekAfterDetach = () => {
+        if (parseInt(this._lastTimeDetach) === parseInt(this.duration)) {
+          this.currentTime = 0;
+        } else {
+          this.currentTime = this._lastTimeDetach;
+        }
         this._lastTimeDetach = NaN;
       };
       if (!isNaN(this._lastTimeDetach)) {
-        const seekTo = playbackEnded ? 0 : this._lastTimeDetach;
-        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach(seekTo));
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach());
       }
       this._isMediaAttached = true;
     }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -422,11 +422,11 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       }
       this._init();
       if (!isNaN(this._lastTimeDetach) && !playbackEnded) {
-        const canPlayHandler = () => {
+        const loadedDataHandler = () => {
           this.currentTime = this._lastTimeDetach;
           this._lastTimeDetach = NaN;
         };
-        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, canPlayHandler);
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, loadedDataHandler);
       } else {
         this._eventManager.listenOnce(this._videoElement, EventType.PLAY, () => (this.currentTime = 0));
         this._lastTimeDetach = NaN;

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -426,7 +426,10 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
           this.currentTime = this._lastTimeDetach;
           this._lastTimeDetach = NaN;
         };
-        this._eventManager.listenOnce(this._videoElement, EventType.CAN_PLAY, canPlayHandler);
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, canPlayHandler);
+      } else {
+        this._eventManager.listenOnce(this._videoElement, EventType.PLAY, () => (this.currentTime = 0));
+        this._lastTimeDetach = NaN;
       }
     }
   }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -445,7 +445,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   detachMediaSource(): void {
     if (this._isMediaAttached) {
-      this._isMediaAttached = false;
       this._lastTimeDetach = this.currentTime;
       this._reset().then(() => {
         this._shaka = null;
@@ -576,6 +575,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._buffering = false;
     this._waitingSent = false;
     this._playingSent = false;
+    this._isMediaAttached = false;
     this._clearVideoUpdateTimer();
     if (this._eventManager) {
       this._eventManager.removeAll();

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -414,22 +414,19 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @param {boolean} playbackEnded playback ended after ads and media
    * @returns {void}
    */
-  attachMediaSource(playbackEnded: ?boolean): void {
-    if (!this._shaka) {
+  attachMediaSource(playbackEnded: boolean): void {
+    if (!this._hls) {
       if (this._videoElement && this._videoElement.src) {
         Utils.Dom.setAttribute(this._videoElement, 'src', '');
         Utils.Dom.removeAttribute(this._videoElement, 'src');
       }
       this._init();
-      if (!isNaN(this._lastTimeDetach) && !playbackEnded) {
-        const loadedDataHandler = () => {
-          this.currentTime = this._lastTimeDetach;
-          this._lastTimeDetach = NaN;
-        };
-        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, loadedDataHandler);
-      } else {
-        this._eventManager.listenOnce(this._videoElement, EventType.PLAY, () => (this.currentTime = 0));
+      const _seekAfterDetach = seekTo => {
+        this.currentTime = seekTo;
         this._lastTimeDetach = NaN;
+      };
+      if (!isNaN(this._lastTimeDetach)) {
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach(playbackEnded ? 0 : this._lastTimeDetach));
       }
     }
   }


### PR DESCRIPTION
### Description of the Changes

Add support for replay after ads finish to return to beginning

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
