### PR TITLE
fix(FEC-9316): seek doesn't work before video finished loading

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -461,7 +461,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         this._lastTimeDetach = NaN;
       };
       if (!isNaN(this._lastTimeDetach)) {
-        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, () => _seekAfterDetach());
+        this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, _seekAfterDetach);
+        this._eventManager.listenOnce(
+          this._videoElement,
+          EventType.SEEKED,
+          this._eventManager.unlisten(this._videoElement, EventType.LOADED_DATA, _seekAfterDetach)
+        );
       }
     }
   }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -462,9 +462,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       };
       if (!isNaN(this._lastTimeDetach)) {
         this._eventManager.listenOnce(this._videoElement, EventType.LOADED_DATA, _seekAfterDetach);
-        this._eventManager.listenOnce(
-          this._videoElement,
-          EventType.SEEKED,
+        this._eventManager.listenOnce(this._videoElement, EventType.SEEKED, () =>
           this._eventManager.unlisten(this._videoElement, EventType.LOADED_DATA, _seekAfterDetach)
         );
       }


### PR DESCRIPTION
### Description of the Changes

occurred on DRM content only `LOAD_DATA` on SMART TV could take a moment and user can seek before - check if `SEEKED` event occurred before.
Couldn't resolve with `LOADED_METADATA` seek failed on earlier version of TV.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
