### PR TITLE
fix(FEC-9379): Edge DRM chose Widevine

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1,6 +1,6 @@
 // @flow
 import shaka from 'shaka-player';
-import {AudioTrack, BaseMediaSourceAdapter, Error, EventType, TextTrack, Track, Utils, VideoTrack, RequestType} from '@playkit-js/playkit-js';
+import {AudioTrack, BaseMediaSourceAdapter, Error, EventType, TextTrack, Track, Utils, VideoTrack, RequestType, Env} from '@playkit-js/playkit-js';
 import Widevine from './drm/widevine';
 import PlayReady from './drm/playready';
 import DefaultConfig from './default-config';
@@ -58,7 +58,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @private
    * @static
    */
-  static _drmProtocols: Array<Function> = [Widevine, PlayReady];
+  static _drmProtocols: Array<Function> = Env.browser.name === 'Edge' ? [PlayReady, Widevine] : [Widevine, PlayReady];
   /**
    * The DRM protocols available for the current playback.
    * @type {Array<Function>}


### PR DESCRIPTION
### Description of the Changes

Win 10 `Edge` has `PlayReady` software support and `Widevine` software support, lower version of windows support `Widevine` only.
Change the selection order of DRM protocol for `Edge`, if there isn't `PlayReady` it'll choose `Widevine` in Shaka player.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
