### PR TITLE
feat(FEC-9109): add DRM Load time metric

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "mocha": "^3.2.0",
     "mocha-cli": "^1.0.1",
     "prettier": "^1.13.7",
-    "shaka-player": "^2.5.5",
+    "shaka-player": "^2.5.9",
     "sinon": "^2.0.0",
     "sinon-chai": "^2.8.0",
     "standard-version": "^4.0.0",

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1,17 +1,6 @@
 // @flow
 import shaka from 'shaka-player';
-import {
-  AudioTrack,
-  BaseMediaSourceAdapter,
-  Error,
-  EventType,
-  CustomEventType,
-  TextTrack,
-  Track,
-  Utils,
-  VideoTrack,
-  RequestType
-} from '@playkit-js/playkit-js';
+import {AudioTrack, BaseMediaSourceAdapter, Error, EventType, TextTrack, Track, Utils, VideoTrack, RequestType} from '@playkit-js/playkit-js';
 import Widevine from './drm/widevine';
 import PlayReady from './drm/playready';
 import DefaultConfig from './default-config';
@@ -561,6 +550,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._eventManager.listen(this._shaka, ShakaEvent.ADAPTATION, this._adapterEventsBindings.adaptation);
     this._eventManager.listen(this._shaka, ShakaEvent.ERROR, this._adapterEventsBindings.error);
     this._eventManager.listen(this._shaka, ShakaEvent.BUFFERING, this._adapterEventsBindings.buffering);
+    this._eventManager.listen(this._shaka, ShakaEvent.DRM_SESSION_UPDATE, this._adapterEventsBindings.drmsessionupdate);
     this._eventManager.listen(this._videoElement, EventType.WAITING, this._adapterEventsBindings.waiting);
     this._eventManager.listen(this._videoElement, EventType.PLAYING, this._adapterEventsBindings.playing);
     // called when a resource is downloaded
@@ -971,7 +961,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _onDrmSessionUpdate(): void {
-    this._videoElement.dispatchEvent(new window.Event(CustomEventType.WAITING));
+    this._trigger(EventType.DRM_LICENSE_RESPONSE, {licenseTime: this._shaka.getStats().licenseTime});
   }
 
   /**

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1,11 +1,21 @@
 // @flow
 import shaka from 'shaka-player';
-import {AudioTrack, BaseMediaSourceAdapter, Error, EventType, TextTrack, Track, Utils, VideoTrack, RequestType} from '@playkit-js/playkit-js';
+import {
+  DrmScheme,
+  AudioTrack,
+  BaseMediaSourceAdapter,
+  Error,
+  EventType,
+  TextTrack,
+  Track,
+  Utils,
+  VideoTrack,
+  RequestType
+} from '@playkit-js/playkit-js';
 import Widevine from './drm/widevine';
 import PlayReady from './drm/playready';
 import DefaultConfig from './default-config';
 import TextDisplayer from './text-displayer';
-
 type ShakaEventType = {[event: string]: string};
 
 /**
@@ -961,9 +971,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _onDrmSessionUpdate(): void {
-    if (this._shaka.getStats() && typeof this._shaka.getStats().licenseTime === 'number') {
-      this._trigger(EventType.DRM_LICENSE_RESPONSE, {licenseTime: this._shaka.getStats().licenseTime});
-    }
+    this._trigger(EventType.DRM_LICENSE_LOADED, {licenseTime: this._shaka.getStats().licenseTime, scheme: DrmScheme.WIDEVINE});
   }
 
   /**

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -961,7 +961,9 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _onDrmSessionUpdate(): void {
-    this._trigger(EventType.DRM_LICENSE_RESPONSE, {licenseTime: this._shaka.getStats().licenseTime});
+    if (this._shaka.getStats() && typeof this._shaka.getStats().licenseTime === 'number') {
+      this._trigger(EventType.DRM_LICENSE_RESPONSE, {licenseTime: this._shaka.getStats().licenseTime});
+    }
   }
 
   /**

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1,6 +1,17 @@
 // @flow
 import shaka from 'shaka-player';
-import {AudioTrack, BaseMediaSourceAdapter, Error, EventType, TextTrack, Track, Utils, VideoTrack, RequestType} from '@playkit-js/playkit-js';
+import {
+  AudioTrack,
+  BaseMediaSourceAdapter,
+  Error,
+  EventType,
+  CustomEventType,
+  TextTrack,
+  Track,
+  Utils,
+  VideoTrack,
+  RequestType
+} from '@playkit-js/playkit-js';
 import Widevine from './drm/widevine';
 import PlayReady from './drm/playready';
 import DefaultConfig from './default-config';
@@ -16,7 +27,8 @@ type ShakaEventType = {[event: string]: string};
 const ShakaEvent: ShakaEventType = {
   ERROR: 'error',
   ADAPTATION: 'adaptation',
-  BUFFERING: 'buffering'
+  BUFFERING: 'buffering',
+  DRM_SESSION_UPDATE: 'drmsessionupdate'
 };
 
 /**
@@ -88,6 +100,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     [ShakaEvent.ERROR]: event => this._onError(event),
     [ShakaEvent.ADAPTATION]: () => this._onAdaptation(),
     [ShakaEvent.BUFFERING]: event => this._onBuffering(event),
+    [ShakaEvent.DRM_SESSION_UPDATE]: () => this._onDrmSessionUpdate(),
     [EventType.WAITING]: () => this._onWaiting(),
     [EventType.PLAYING]: () => this._onPlaying()
   };
@@ -949,6 +962,16 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         this._videoElement.dispatchEvent(new window.Event(EventType.PLAYING));
       }
     }
+  }
+
+  /**
+   * An handler to shaka drm session update event
+   * @function _onDrmSessionUpdate
+   * @returns {void}
+   * @private
+   */
+  _onDrmSessionUpdate(): void {
+    this._videoElement.dispatchEvent(new window.Event(CustomEventType.WAITING));
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,6 +1840,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+eme-encryption-scheme-polyfill@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.0.0.tgz#b44a8fb7d5c7c0be869897be9d77a8cb9c0ba795"
+  integrity sha512-/zoXuACHLGQ8w5nkJrVr3YI0IGe05ZS8HR1x5uTqiAoHuj5hPzdnoyW9Zom8iPv93arPzwpde93GrKCFKLFK4g==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -5057,10 +5062,12 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
 
-shaka-player@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-2.5.5.tgz#81e7265f28f631afd3837c06ec6637824bda71e4"
-  integrity sha512-YEWBFapWKjwy2+wIgH9NqoFW9A14LIYNAoJ9cQr3c9BGS7qjqxeiYM/H1BJ8so1FQexpsWUdyjwHvcspdc7/nw==
+shaka-player@^2.5.9:
+  version "2.5.9"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-2.5.9.tgz#007dc19df2bb5d3d959d278b2d894af05adffe38"
+  integrity sha512-XavLBqxvIbvLOPfk7VKZu5fbMJyVko9bBfzxmMWdX5bvQwUSjU7ZhV8v2tHqXQYafpHml1hlGHzKkLs7idouNQ==
+  dependencies:
+    eme-encryption-scheme-polyfill "^2.0.0"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
### Description of the Changes

to use new licenseTime stats metric from Shaka upgraded Shaka to 2.5.9
listening to DRM_SESSION_UPDATE shaka event and triggering new DRM_LICENSE_RESPONSE playkit event with the license time

Solves FEC-9109

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
