### PR TITLE
feat(FEC-10435): upgrade shaka for fixing live issue and optimizations for smartTV

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "mocha": "^8.0.1",
     "mocha-cli": "^1.0.1",
     "prettier": "^2.0.5",
-    "shaka-player": "2.5.13",
+    "shaka-player": "3.0.4",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "standard-version": "^6.0.1",
@@ -84,8 +84,8 @@
     "webpack-dev-server": "^3.11.0"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "0.62.1-canary.2264c8f",
-    "shaka-player": "2.5.13"
+    "@playkit-js/playkit-js": "0.63.0",
+    "shaka-player": "3.0.4"
   },
   "keywords": [
     "kaltura",

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1077,24 +1077,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   }
 
   _getCurrentSegmentLength(): number {
-    const activeTrack = this._getActiveTrack();
-    const activeTrackId = activeTrack ? activeTrack.id : NaN;
-    let segmentLength = 0;
-    if (this._shaka.getManifest()) {
-      const periods = this._shaka.getManifest().periods;
-      if (!isNaN(activeTrackId) && periods) {
-        for (let i = 0; i < periods.length; i++) {
-          for (let j = 0; j < periods[i].variants.length; j++) {
-            const variant = periods[i].variants[j];
-            if (variant.id === activeTrackId) {
-              const segmentPosition = variant.video.findSegmentPosition(this._videoElement.currentTime);
-              let seg = variant.video.getSegmentReference(segmentPosition);
-              segmentLength = seg.endTime - seg.startTime;
-            }
-          }
-        }
-      }
-    }
-    return segmentLength;
+    return this._shaka.getManifest().presentationTimeline.getMaxSegmentDuration();
   }
 }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1072,11 +1072,10 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       targetBufferVal = this._videoElement.duration - this._videoElement.currentTime;
     }
 
-    targetBufferVal = Math.min(targetBufferVal, this._shaka.getConfiguration().streaming.bufferingGoal + this._getCurrentSegmentLength());
+    targetBufferVal = Math.min(
+      targetBufferVal,
+      this._shaka.getConfiguration().streaming.bufferingGoal + this._shaka.getManifest().presentationTimeline.getMaxSegmentDuration()
+    );
     return targetBufferVal;
-  }
-
-  _getCurrentSegmentLength(): number {
-    return this._shaka.getManifest().presentationTimeline.getMaxSegmentDuration();
   }
 }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1061,7 +1061,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     let targetBufferVal = NaN;
     if (!this._shaka) return NaN;
     if (this.isLive()) {
-      if (this._shaka.getManifest()) {
+      if (this._shaka.getManifest() && this._shaka.getManifest().presentationTimeline) {
         targetBufferVal =
           this._shaka.getManifest().presentationTimeline.getSegmentAvailabilityEnd() -
           this._shaka.getManifest().presentationTimeline.getSeekRangeEnd() -
@@ -1072,10 +1072,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       targetBufferVal = this._videoElement.duration - this._videoElement.currentTime;
     }
 
-    targetBufferVal = Math.min(
-      targetBufferVal,
-      this._shaka.getConfiguration().streaming.bufferingGoal + this._shaka.getManifest().presentationTimeline.getMaxSegmentDuration()
-    );
+    if (this._shaka.getManifest() && this._shaka.getManifest().presentationTimeline) {
+      targetBufferVal = Math.min(
+        targetBufferVal,
+        this._shaka.getConfiguration().streaming.bufferingGoal + this._shaka.getManifest().presentationTimeline.getMaxSegmentDuration()
+      );
+    }
     return targetBufferVal;
   }
 }

--- a/src/default-config.json
+++ b/src/default-config.json
@@ -1,7 +1,8 @@
 {
   "shakaConfig": {
     "streaming": {
-      "ignoreTextStreamFailures": true
+      "ignoreTextStreamFailures": true,
+      "bufferingGoal": 60
     },
     "abr": {
       "enabled": true,

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -273,9 +273,10 @@ describe('DashAdapter: targetBuffer', () => {
     try {
       dashInstance = DashAdapter.createAdapter(video, vodSource, config);
       video.addEventListener(EventType.PLAYING, () => {
-        dashInstance.targetBuffer.should.equal(
-          dashInstance._shaka.getConfiguration().streaming.bufferingGoal + dashInstance._getCurrentSegmentLength()
-        );
+        const targetBufferVal =
+          dashInstance._shaka.getConfiguration().streaming.bufferingGoal + dashInstance._getCurrentSegmentLength();
+        Math.round(dashInstance.targetBuffer - targetBufferVal).should.equal(0);
+
         done();
       });
       dashInstance.load().then(() => {
@@ -292,7 +293,7 @@ describe('DashAdapter: targetBuffer', () => {
       dashInstance._eventManager.listenOnce(video, EventType.PLAYING, () => {
         video.currentTime = video.duration - 1;
         dashInstance._eventManager.listenOnce(video, EventType.SEEKED, () => {
-          dashInstance.targetBuffer.should.equal(video.duration - video.currentTime);
+          Math.round(dashInstance.targetBuffer - video.duration + video.currentTime).should.equal(0);
           done();
         });
       });
@@ -318,7 +319,7 @@ describe('DashAdapter: targetBuffer', () => {
           dashInstance._shaka.getManifest().presentationTimeline.getSeekRangeEnd() -
           (video.currentTime - dashInstance._getLiveEdge());
 
-        (dashInstance.targetBuffer.toFixed(2) === targetBufferVal.toFixed(2)).should.be.true;
+        Math.round(dashInstance.targetBuffer - targetBufferVal).should.equal(0);
         done();
       });
 
@@ -340,7 +341,7 @@ describe('DashAdapter: targetBuffer', () => {
       video.addEventListener(EventType.PLAYING, () => {
         let targetBufferVal = dashInstance._shaka.getConfiguration().streaming.bufferingGoal + dashInstance._getCurrentSegmentLength();
 
-        (dashInstance.targetBuffer.toFixed(2) === targetBufferVal.toFixed(2)).should.be.true;
+        Math.round(dashInstance.targetBuffer - targetBufferVal).should.equal(0);
         done();
       });
 
@@ -1487,8 +1488,8 @@ describe('DashAdapter: request filter', () => {
 
   describe('http request', () => {
     after(() => {
-      shaka.net.NetworkingEngine.registerScheme('http', shaka.net.HttpFetchPlugin, shaka.net.NetworkingEngine.PluginPriority.PREFERRED);
-      shaka.net.NetworkingEngine.registerScheme('https', shaka.net.HttpFetchPlugin, shaka.net.NetworkingEngine.PluginPriority.PREFERRED);
+      shaka.net.NetworkingEngine.registerScheme('http', shaka.net.HttpFetchPlugin.parse, shaka.net.NetworkingEngine.PluginPriority.PREFERRED);
+      shaka.net.NetworkingEngine.registerScheme('https', shaka.net.HttpFetchPlugin.parse, shaka.net.NetworkingEngine.PluginPriority.PREFERRED);
     });
 
     it('should apply void filter for manifest', done => {

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -274,7 +274,8 @@ describe('DashAdapter: targetBuffer', () => {
       dashInstance = DashAdapter.createAdapter(video, vodSource, config);
       video.addEventListener(EventType.PLAYING, () => {
         const targetBufferVal =
-          dashInstance._shaka.getConfiguration().streaming.bufferingGoal + dashInstance._getCurrentSegmentLength();
+          dashInstance._shaka.getConfiguration().streaming.bufferingGoal +
+          dashInstance._shaka.getManifest().presentationTimeline.getMaxSegmentDuration();
         Math.round(dashInstance.targetBuffer - targetBufferVal).should.equal(0);
 
         done();
@@ -339,7 +340,9 @@ describe('DashAdapter: targetBuffer', () => {
         Utils.Object.mergeDeep(config, {playback: {options: {html5: {dash: {streaming: {bufferingGoal: 10}}}}}})
       );
       video.addEventListener(EventType.PLAYING, () => {
-        let targetBufferVal = dashInstance._shaka.getConfiguration().streaming.bufferingGoal + dashInstance._getCurrentSegmentLength();
+        let targetBufferVal =
+          dashInstance._shaka.getConfiguration().streaming.bufferingGoal +
+          dashInstance._shaka.getManifest().presentationTimeline.getMaxSegmentDuration();
 
         Math.round(dashInstance.targetBuffer - targetBufferVal).should.equal(0);
         done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6910,10 +6910,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaka-player@2.5.13:
-  version "2.5.13"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-2.5.13.tgz#f8c493b825c735fc86d619cba8b2eb2f2a382233"
-  integrity sha512-rEh7juGlTvvF10oD7+EukS12EysZXI2fiGvNLqO7GsBQ5R/sFwcTGEB8A6lWlHQXeGVbT+MxZWKMZwFE805G6A==
+shaka-player@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-3.0.4.tgz#241245f4019b3550ef58d6f83b8fc75c66ab8816"
+  integrity sha512-sjmArz8ukKNx5SU2O99kdJr1Z3TyDRn/p11ivUm/67jptCgYuIGI8swfvkJO5KD7MBJSaBP6z32D38dBx5AAxA==
   dependencies:
     eme-encryption-scheme-polyfill "^2.0.1"
 


### PR DESCRIPTION
### Description of the Changes

Issue: encrypted liner channel sometimes constantly changes from buffering to playing
Solution: upgrade shaka - fixes for live and smartTV optimizations - added fixes for test and change the default bufferingGoal to 60s as we have for HLS.
remove `_getCurrentSegmentLength` which calculated from a recent segment that doesn't fit shaka calculation which used `getMaxSegmentDuration` instead.

Solve: FEC-10435.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
