### PR TITLE
fix(FEC-10840): incorrect waiting and playing event comes from dash adapter

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -612,10 +612,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   _addBindings(): void {
     this._eventManager.listen(this._shaka, ShakaEvent.ADAPTATION, this._adapterEventsBindings.adaptation);
     this._eventManager.listen(this._shaka, ShakaEvent.ERROR, this._adapterEventsBindings.error);
-    this._eventManager.listen(this._shaka, ShakaEvent.BUFFERING, this._adapterEventsBindings.buffering);
     this._eventManager.listen(this._shaka, ShakaEvent.DRM_SESSION_UPDATE, this._adapterEventsBindings.drmsessionupdate);
     this._eventManager.listen(this._videoElement, EventType.WAITING, this._adapterEventsBindings.waiting);
     this._eventManager.listen(this._videoElement, EventType.PLAYING, this._adapterEventsBindings.playing);
+    this._eventManager.listenOnce(this._videoElement, EventType.PLAYING, () =>
+      this._eventManager.listen(this._shaka, ShakaEvent.BUFFERING, this._adapterEventsBindings.buffering)
+    );
     // called when a resource is downloaded
     this._shaka.getNetworkingEngine().registerResponseFilter((type, response) => {
       switch (type) {

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -1204,7 +1204,7 @@ describe('DashAdapter: _onBuffering', () => {
     dashInstance._onBuffering({buffering: true});
   });
 
-  it('should dispatch playing event when buffering is false and video is playing', done => {
+  it('should dispatch playing event when buffering is false and video is playing after waiting event', done => {
     dashInstance = DashAdapter.createAdapter(video, vodSource, config);
     let hasPlaying = false;
     let onPlaying = () => {
@@ -1213,10 +1213,15 @@ describe('DashAdapter: _onBuffering', () => {
         done();
       } else {
         hasPlaying = true;
-        dashInstance._onBuffering({buffering: false});
+        dashInstance._onBuffering({buffering: true});
       }
     };
+    const onWaiting = () => {
+      dashInstance._videoElement.removeEventListener(EventType.WAITING, onWaiting);
+      dashInstance._onBuffering({buffering: false});
+    };
     dashInstance._videoElement.addEventListener(EventType.PLAYING, onPlaying);
+    dashInstance._videoElement.addEventListener(EventType.WAITING, onWaiting);
     dashInstance
       .load()
       .then(() => {


### PR DESCRIPTION
### Description of the Changes

Issue: adapter fire waiting and playing before it fired from the video element.
There is an incorrect situation when playing fired twice for DRM content and waiting fired before play.
Solution: use this mechanism only after first playing to make sure that buffering will be handled after first playing when buffering should change the buffering state.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
