### PR TITLE
feat(FEC-10973): parse image tracks from dash manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.21.2](https://github.com/kaltura/playkit-js-dash/compare/v1.21.1...v1.21.2) (2021-01-28)
+
+
+
 ### [1.21.1](https://github.com/kaltura/playkit-js-dash/compare/v1.21.0...v1.21.1) (2021-01-28)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playkit-js/playkit-js-dash",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "description": "",
   "main": "dist/playkit-dash.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,20 +2,44 @@
   "name": "@playkit-js/playkit-js-dash",
   "version": "1.21.2",
   "description": "",
+  "keywords": [
+    "kaltura",
+    "dash",
+    "shaka-player",
+    "mse",
+    "player",
+    "playkit-js",
+    "playkit-js-dash",
+    "html5 player"
+  ],
+  "homepage": "https://github.com/kaltura/playkit-js-dash#readme",
+  "bugs": {
+    "url": "https://github.com/kaltura/playkit-js-dash/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaltura/playkit-js-dash.git"
+  },
+  "license": "AGPL-3.0",
   "main": "dist/playkit-dash.js",
   "scripts": {
-    "clean": "rm -rf ./dist",
     "prebuild": "npm run clean",
     "build": "webpack --mode production",
+    "clean": "rm -rf ./dist",
     "dev": "webpack-dev-server --mode development",
-    "watch": "webpack --progress --colors --watch --mode development",
-    "test": "NODE_ENV=test karma start --color --mode development",
-    "release": "standard-version",
-    "pushTaggedRelease": "git push --follow-tags --no-verify origin master",
     "eslint": "eslint . --color",
     "flow": "flow check",
     "precommit": "lint-staged",
-    "prettier:fix": "prettier --write ."
+    "prettier:fix": "prettier --write .",
+    "pushTaggedRelease": "git push --follow-tags --no-verify origin master",
+    "release": "standard-version",
+    "test": "NODE_ENV=test karma start --color --mode development",
+    "watch": "webpack --progress --colors --watch --mode development"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   },
   "lint-staged": {
     "*.{js,jsx}": [
@@ -26,9 +50,6 @@
       "prettier --write",
       "git add"
     ]
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",
@@ -86,25 +107,9 @@
     "@playkit-js/playkit-js": "0.65.0",
     "shaka-player": "3.0.7"
   },
-  "keywords": [
-    "kaltura",
-    "dash",
-    "shaka-player",
-    "mse",
-    "player",
-    "playkit-js",
-    "playkit-js-dash",
-    "html5 player"
-  ],
-  "license": "AGPL-3.0",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/kaltura/playkit-js-dash.git"
+  "publishConfig": {
+    "access": "public"
   },
-  "bugs": {
-    "url": "https://github.com/kaltura/playkit-js-dash/issues"
-  },
-  "homepage": "https://github.com/kaltura/playkit-js-dash#readme",
   "kcc": {
     "name": "playkit-dash"
   }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -642,8 +642,10 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @returns {void}
    */
   _parseManifest(manifestBuffer: ArrayBuffer): void {
-    this._manifestParser = new DashManifestParser(manifestBuffer);
-    this._manifestParser.parseManifest();
+    if (DashManifestParser.isValid()) {
+      this._manifestParser = new DashManifestParser(manifestBuffer);
+      this._manifestParser.parseManifest();
+    }
   }
 
   /**

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -172,6 +172,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _isDestroyInProgress: boolean = false;
+  /**
+   * Custom dash manifest parser.
+   * @type {DashManifestParser}
+   * @private
+   */
+  _manifestParser: DashManifestParser;
 
   /**
    * Factory method to create media source adapter.
@@ -637,6 +643,13 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     });
   }
 
+  /**
+   * Custom parser to retrieve image adaptation sets.
+   * @param {ArrayBuffer} manifestBuffer - The array buffer manifest from the response.
+   * @function _parseManifest
+   * @private
+   * @returns {void}
+   */
   _parseManifest(manifestBuffer: ArrayBuffer): void {
     this._manifestParser = new DashManifestParser(manifestBuffer);
     this._manifestParser.parseManifest();

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1,21 +1,22 @@
 // @flow
 import shaka from 'shaka-player';
 import {
-  DrmScheme,
   AudioTrack,
   BaseMediaSourceAdapter,
+  DrmScheme,
   Error,
   EventType,
+  RequestType,
   TextTrack,
   Track,
   Utils,
-  VideoTrack,
-  RequestType
+  VideoTrack
 } from '@playkit-js/playkit-js';
 import {Widevine} from './drm/widevine';
 import {PlayReady} from './drm/playready';
 import DefaultConfig from './default-config';
 import './assets/syle.css';
+import {DashManifestParser} from './parser/dash-manifest-parser';
 
 type ShakaEventType = {[event: string]: string};
 
@@ -367,6 +368,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       }
     });
   }
+
   /**
    * get the redirected URL
    * @param {string} url - The url to check for redirection
@@ -629,10 +631,15 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
           });
           break;
         case shaka.net.NetworkingEngine.RequestType.MANIFEST:
+          this._parseManifest(response.data);
           this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
-          break;
       }
     });
+  }
+
+  _parseManifest(manifestBuffer: ArrayBuffer): void {
+    this._manifestParser = new DashManifestParser(manifestBuffer);
+    this._manifestParser.parseManifest();
   }
 
   /**

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -630,6 +630,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         case shaka.net.NetworkingEngine.RequestType.MANIFEST:
           this._parseManifest(response.data);
           this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
+          break;
       }
     });
   }

--- a/src/parser/adaptation-set.js
+++ b/src/parser/adaptation-set.js
@@ -18,9 +18,9 @@ class AdaptationSet {
   _representations: Array<Representation>;
 
   constructor(elem: HTMLElement) {
-    this._id = XmlUtils.parseAttr(elem, 'id');
-    this._mimeType = XmlUtils.parseAttr(elem, 'mimeType');
-    this._contentType = XmlUtils.parseAttr(elem, 'contentType');
+    this._id = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.ID);
+    this._mimeType = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.MIME_TYPE);
+    this._contentType = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.CONTENT_TYPE);
     this._representations = Array.from(XmlUtils.findChildren(elem, MpdUtils.TagsTypes.REPRESENTATION)).map(repElem => new Representation(repElem));
     const segTempElem = XmlUtils.findChild(elem, MpdUtils.TagsTypes.SEGMENT_TEMPLATE);
     if (segTempElem) {

--- a/src/parser/adaptation-set.js
+++ b/src/parser/adaptation-set.js
@@ -1,7 +1,7 @@
 // @flow
 import {SegmentTemplate} from './segment-template';
 import {Representation} from './representation';
-import {XmlUtils, MpdUtils} from './parser-utils';
+import {MpdUtils, XmlUtils} from './parser-utils';
 
 class AdaptationSet {
   static ContentType: {[type: string]: string} = {

--- a/src/parser/adaptation-set.js
+++ b/src/parser/adaptation-set.js
@@ -2,6 +2,7 @@
 import {SegmentTemplate} from './segment-template';
 import {Representation} from './representation';
 import {MpdUtils, XmlUtils} from './parser-utils';
+import {EssentialProperty} from './essential-property';
 
 class AdaptationSet {
   static ContentType: {[type: string]: string} = {
@@ -15,6 +16,7 @@ class AdaptationSet {
   _mimeType: string;
   _contentType: string;
   _segmentTemplate: SegmentTemplate;
+  _essentialProperty: ?EssentialProperty;
   _representations: Array<Representation>;
 
   constructor(elem: HTMLElement) {
@@ -25,6 +27,10 @@ class AdaptationSet {
     const segTempElem = XmlUtils.findChild(elem, MpdUtils.TagTypes.SEGMENT_TEMPLATE);
     if (segTempElem) {
       this._segmentTemplate = new SegmentTemplate(segTempElem);
+    }
+    const essPropElem = XmlUtils.findChild(elem, MpdUtils.TagTypes.ESSENTIAL_PROPERTY);
+    if (essPropElem) {
+      this._essentialProperty = new EssentialProperty(essPropElem);
     }
   }
 
@@ -42,6 +48,10 @@ class AdaptationSet {
 
   get segmentTemplate(): SegmentTemplate {
     return this._segmentTemplate;
+  }
+
+  get essentialProperty(): ?EssentialProperty {
+    return this._essentialProperty;
   }
 
   get representations(): Array<Representation> {

--- a/src/parser/adaptation-set.js
+++ b/src/parser/adaptation-set.js
@@ -18,11 +18,11 @@ class AdaptationSet {
   _representations: Array<Representation>;
 
   constructor(elem: HTMLElement) {
-    this._id = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.ID);
-    this._mimeType = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.MIME_TYPE);
-    this._contentType = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.CONTENT_TYPE);
-    this._representations = Array.from(XmlUtils.findChildren(elem, MpdUtils.TagsTypes.REPRESENTATION)).map(repElem => new Representation(repElem));
-    const segTempElem = XmlUtils.findChild(elem, MpdUtils.TagsTypes.SEGMENT_TEMPLATE);
+    this._id = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.ID);
+    this._mimeType = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.MIME_TYPE);
+    this._contentType = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.CONTENT_TYPE);
+    this._representations = Array.from(XmlUtils.findChildren(elem, MpdUtils.TagTypes.REPRESENTATION)).map(repElem => new Representation(repElem));
+    const segTempElem = XmlUtils.findChild(elem, MpdUtils.TagTypes.SEGMENT_TEMPLATE);
     if (segTempElem) {
       this._segmentTemplate = new SegmentTemplate(segTempElem);
     }

--- a/src/parser/adaptation-set.js
+++ b/src/parser/adaptation-set.js
@@ -1,0 +1,52 @@
+// @flow
+import {SegmentTemplate} from './segment-template';
+import {Representation} from './representation';
+import {XmlUtils, MpdUtils} from './parser-utils';
+
+class AdaptationSet {
+  static ContentType: {[type: string]: string} = {
+    VIDEO: 'video',
+    AUDIO: 'audio',
+    TEXT: 'text',
+    IMAGE: 'image'
+  };
+
+  _id: string;
+  _mimeType: string;
+  _contentType: string;
+  _segmentTemplate: SegmentTemplate;
+  _representations: Array<Representation>;
+
+  constructor(elem: HTMLElement) {
+    this._id = XmlUtils.parseAttr(elem, 'id');
+    this._mimeType = XmlUtils.parseAttr(elem, 'mimeType');
+    this._contentType = XmlUtils.parseAttr(elem, 'contentType');
+    this._representations = Array.from(XmlUtils.findChildren(elem, MpdUtils.TagsTypes.REPRESENTATION)).map(repElem => new Representation(repElem));
+    const segTempElem = XmlUtils.findChild(elem, MpdUtils.TagsTypes.SEGMENT_TEMPLATE);
+    if (segTempElem) {
+      this._segmentTemplate = new SegmentTemplate(segTempElem);
+    }
+  }
+
+  get id(): string {
+    return this._id;
+  }
+
+  get mimeType(): string {
+    return this._mimeType;
+  }
+
+  get contentType(): string {
+    return this._contentType;
+  }
+
+  get segmentTemplate(): SegmentTemplate {
+    return this._segmentTemplate;
+  }
+
+  get representations(): Array<Representation> {
+    return this._representations;
+  }
+}
+
+export {AdaptationSet};

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -10,7 +10,7 @@ class DashManifestParser {
 
   constructor(manifest: ArrayBuffer) {
     const xmlStr = ParserUtils.BufferToStr(manifest);
-    this._logger.debug('Initialize manifest parser', xmlStr);
+    this._logger.debug('Initialize manifest parser', manifest, xmlStr);
     this._xmlDoc = XmlUtils.parseXml(xmlStr);
     this._adaptationSets = [];
   }

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -22,22 +22,16 @@ class DashManifestParser {
       this._parseAdaptionSets();
       this._logger.debug('Manifest parsing finished successfully');
     } catch (e) {
-      this._logger.error('Manifest parsing failed', e);
+      this._logger.warn('Manifest parsing failed', e);
     }
   }
 
   getAdaptationSet(type: string): ?AdaptationSet {
-    if (type) {
-      const adaptationSets = this._adaptationSets.filter((adaptationSet: AdaptationSet) => adaptationSet.contentType === type);
-      if (adaptationSets) {
-        return adaptationSets[0];
-      }
-    }
-    return null;
+    return this._adaptationSets.find((adaptationSet: AdaptationSet) => adaptationSet.contentType === type);
   }
 
   _parseAdaptionSets = () => {
-    const adaptationNodes = XmlUtils.findElement(this._xmlDoc, MpdUtils.TagTypes.ADAPTATION_SET);
+    const adaptationNodes = XmlUtils.findElements(this._xmlDoc, MpdUtils.TagTypes.ADAPTATION_SET);
     // For now parse only image adaptation sets
     const imageAdaptationsNodes = Array.from(adaptationNodes).filter(
       adaptation => XmlUtils.parseAttr(adaptation, MpdUtils.AttributeTypes.CONTENT_TYPE) === AdaptationSet.ContentType.IMAGE

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -1,0 +1,52 @@
+// @flow
+import {ParserUtils, XmlUtils, MpdUtils} from './parser-utils';
+import {AdaptationSet} from './adaptation-set';
+import {getLogger} from '@playkit-js/playkit-js';
+
+class DashManifestParser {
+  _logger: any = getLogger('DashManifestParser');
+  _xmlDoc: Document;
+  _adaptationSets: Array<AdaptationSet>;
+
+  constructor(manifest: ArrayBuffer) {
+    const xmlStr = ParserUtils.BufferToStr(manifest);
+    this._xmlDoc = XmlUtils.parseXml(xmlStr);
+    this._adaptationSets = [];
+  }
+
+  parseManifest() {
+    try {
+      // for now parse only adaptation sets
+      this._parseAdaptionSets();
+    } catch (e) {
+      this._logger.error('Manifest parsing failed.', e);
+    }
+  }
+
+  _parseAdaptionSets() {
+    const adaptationNodes = XmlUtils.findElement(this._xmlDoc, MpdUtils.TagsTypes.ADAPTATION_SET);
+    // for now parse only image adaptation sets
+    const imageAdaptationsNodes = Array.from(adaptationNodes).filter(
+      adaptation => XmlUtils.parseAttr(adaptation, 'contentType') === AdaptationSet.ContentType.IMAGE
+    );
+    if (imageAdaptationsNodes.length > 0) {
+      this._adaptationSets = imageAdaptationsNodes.map(adaptation => new AdaptationSet(adaptation));
+    }
+  }
+
+  getAdaptationSet(type: string): ?AdaptationSet {
+    if (type) {
+      const adaptationSets = this._adaptationSets.filter((adaptationSet: AdaptationSet) => adaptationSet.contentType === type);
+      if (adaptationSets) {
+        return adaptationSets[0];
+      }
+    }
+    return null;
+  }
+
+  get adaptationSets(): Array<AdaptationSet> {
+    return this._adaptationSets;
+  }
+}
+
+export {DashManifestParser};

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -9,8 +9,8 @@ class DashManifestParser {
   _adaptationSets: Array<AdaptationSet>;
 
   constructor(manifest: ArrayBuffer) {
-    this._logger.debug('Initialize manifest parser', manifest);
     const xmlStr = ParserUtils.BufferToStr(manifest);
+    this._logger.debug('Initialize manifest parser', xmlStr);
     this._xmlDoc = XmlUtils.parseXml(xmlStr);
     this._adaptationSets = [];
   }

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -10,9 +10,9 @@ class DashManifestParser {
 
   constructor(manifest: ArrayBuffer) {
     this._logger.debug('Initialize manifest parser');
+    this._adaptationSets = [];
     const xmlStr = ParserUtils.BufferToStr(manifest);
     this._xmlDoc = XmlUtils.parseXml(xmlStr);
-    this._adaptationSets = [];
   }
 
   parseManifest() {

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -1,5 +1,5 @@
 // @flow
-import {ParserUtils, XmlUtils, MpdUtils} from './parser-utils';
+import {MpdUtils, ParserUtils, XmlUtils} from './parser-utils';
 import {AdaptationSet} from './adaptation-set';
 import {getLogger} from '@playkit-js/playkit-js';
 

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -8,11 +8,17 @@ class DashManifestParser {
   _xmlDoc: Document;
   _adaptationSets: Array<AdaptationSet>;
 
+  static isValid(): boolean {
+    return window.TextEncoder && window.TextDecoder;
+  }
+
   constructor(manifest: ArrayBuffer) {
     this._logger.debug('Initialize manifest parser');
     this._adaptationSets = [];
     const xmlStr = ParserUtils.BufferToStr(manifest);
-    this._xmlDoc = XmlUtils.parseXml(xmlStr);
+    if (xmlStr) {
+      this._xmlDoc = XmlUtils.parseXml(xmlStr);
+    }
   }
 
   parseManifest() {

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -45,6 +45,8 @@ class DashManifestParser {
     if (imageAdaptationsNodes.length > 0) {
       this._adaptationSets = imageAdaptationsNodes.map(adaptation => new AdaptationSet(adaptation));
       this._logger.debug('Found image adaptation set', this._adaptationSets);
+    } else {
+      this._logger.debug('No image adaptations were found in manifest');
     }
   };
 

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -36,7 +36,7 @@ class DashManifestParser {
   }
 
   _parseAdaptionSets = () => {
-    const adaptationNodes = XmlUtils.findElement(this._xmlDoc, MpdUtils.TagsTypes.ADAPTATION_SET);
+    const adaptationNodes = XmlUtils.findElement(this._xmlDoc, MpdUtils.TagTypes.ADAPTATION_SET);
     // For now parse only image adaptation sets
     const imageAdaptationsNodes = Array.from(adaptationNodes).filter(
       adaptation => XmlUtils.parseAttr(adaptation, 'contentType') === AdaptationSet.ContentType.IMAGE

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -9,6 +9,7 @@ class DashManifestParser {
   _adaptationSets: Array<AdaptationSet>;
 
   constructor(manifest: ArrayBuffer) {
+    this._logger.debug('Initialize manifest parser', manifest);
     const xmlStr = ParserUtils.BufferToStr(manifest);
     this._xmlDoc = XmlUtils.parseXml(xmlStr);
     this._adaptationSets = [];
@@ -16,21 +17,11 @@ class DashManifestParser {
 
   parseManifest() {
     try {
-      // for now parse only adaptation sets
+      this._logger.debug('Start parsing dash manifest');
+      // For now parse only adaptation sets
       this._parseAdaptionSets();
     } catch (e) {
       this._logger.error('Manifest parsing failed.', e);
-    }
-  }
-
-  _parseAdaptionSets() {
-    const adaptationNodes = XmlUtils.findElement(this._xmlDoc, MpdUtils.TagsTypes.ADAPTATION_SET);
-    // for now parse only image adaptation sets
-    const imageAdaptationsNodes = Array.from(adaptationNodes).filter(
-      adaptation => XmlUtils.parseAttr(adaptation, 'contentType') === AdaptationSet.ContentType.IMAGE
-    );
-    if (imageAdaptationsNodes.length > 0) {
-      this._adaptationSets = imageAdaptationsNodes.map(adaptation => new AdaptationSet(adaptation));
     }
   }
 
@@ -43,6 +34,18 @@ class DashManifestParser {
     }
     return null;
   }
+
+  _parseAdaptionSets = () => {
+    const adaptationNodes = XmlUtils.findElement(this._xmlDoc, MpdUtils.TagsTypes.ADAPTATION_SET);
+    // For now parse only image adaptation sets
+    const imageAdaptationsNodes = Array.from(adaptationNodes).filter(
+      adaptation => XmlUtils.parseAttr(adaptation, 'contentType') === AdaptationSet.ContentType.IMAGE
+    );
+    if (imageAdaptationsNodes.length > 0) {
+      this._adaptationSets = imageAdaptationsNodes.map(adaptation => new AdaptationSet(adaptation));
+      this._logger.debug('Found image adaptation set', this._adaptationSets);
+    }
+  };
 
   get adaptationSets(): Array<AdaptationSet> {
     return this._adaptationSets;

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -9,8 +9,8 @@ class DashManifestParser {
   _adaptationSets: Array<AdaptationSet>;
 
   constructor(manifest: ArrayBuffer) {
+    this._logger.debug('Initialize manifest parser');
     const xmlStr = ParserUtils.BufferToStr(manifest);
-    this._logger.debug('Initialize manifest parser', manifest, xmlStr);
     this._xmlDoc = XmlUtils.parseXml(xmlStr);
     this._adaptationSets = [];
   }
@@ -20,8 +20,9 @@ class DashManifestParser {
       this._logger.debug('Start parsing dash manifest');
       // For now parse only adaptation sets
       this._parseAdaptionSets();
+      this._logger.debug('Manifest parsing finished successfully');
     } catch (e) {
-      this._logger.error('Manifest parsing failed.', e);
+      this._logger.error('Manifest parsing failed', e);
     }
   }
 

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -40,7 +40,7 @@ class DashManifestParser {
     const adaptationNodes = XmlUtils.findElement(this._xmlDoc, MpdUtils.TagTypes.ADAPTATION_SET);
     // For now parse only image adaptation sets
     const imageAdaptationsNodes = Array.from(adaptationNodes).filter(
-      adaptation => XmlUtils.parseAttr(adaptation, 'contentType') === AdaptationSet.ContentType.IMAGE
+      adaptation => XmlUtils.parseAttr(adaptation, MpdUtils.AttributeTypes.CONTENT_TYPE) === AdaptationSet.ContentType.IMAGE
     );
     if (imageAdaptationsNodes.length > 0) {
       this._adaptationSets = imageAdaptationsNodes.map(adaptation => new AdaptationSet(adaptation));

--- a/src/parser/essential-property.js
+++ b/src/parser/essential-property.js
@@ -6,8 +6,8 @@ class EssentialProperty {
   _value: string;
 
   constructor(elem: HTMLElement) {
-    this._schemeIdUri = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.SCHEME_ID_URI);
-    this._value = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.VALUE);
+    this._schemeIdUri = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.SCHEME_ID_URI);
+    this._value = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.VALUE);
   }
 
   get schemeIdUri(): string {

--- a/src/parser/essential-property.js
+++ b/src/parser/essential-property.js
@@ -1,13 +1,13 @@
 // @flow
-import {XmlUtils} from './parser-utils';
+import {MpdUtils, XmlUtils} from './parser-utils';
 
 class EssentialProperty {
   _schemeIdUri: string;
   _value: string;
 
   constructor(elem: HTMLElement) {
-    this._schemeIdUri = XmlUtils.parseAttr(elem, 'schemeIdUri');
-    this._value = XmlUtils.parseAttr(elem, 'value');
+    this._schemeIdUri = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.SCHEME_ID_URI);
+    this._value = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.VALUE);
   }
 
   get schemeIdUri(): string {

--- a/src/parser/essential-property.js
+++ b/src/parser/essential-property.js
@@ -1,0 +1,22 @@
+// @flow
+import {XmlUtils} from './parser-utils';
+
+class EssentialProperty {
+  _schemeIdUri: string;
+  _value: string;
+
+  constructor(elem: HTMLElement) {
+    this._schemeIdUri = XmlUtils.parseAttr(elem, 'schemeIdUri');
+    this._value = XmlUtils.parseAttr(elem, 'value');
+  }
+
+  get schemeIdUri(): string {
+    return this._schemeIdUri;
+  }
+
+  get value(): string {
+    return this._value;
+  }
+}
+
+export {EssentialProperty};

--- a/src/parser/parser-utils.js
+++ b/src/parser/parser-utils.js
@@ -1,12 +1,18 @@
 // @flow
 const ParserUtils = {
-  BufferToStr: (buffer: ArrayBuffer): string => {
-    const textDecoder = new TextDecoder();
-    return textDecoder.decode(buffer);
+  BufferToStr: (buffer: ArrayBuffer): ?string => {
+    if (TextDecoder) {
+      const textDecoder = new TextDecoder();
+      return textDecoder.decode(buffer);
+    }
+    return null;
   },
-  StrToBuffer: (str: string): Uint8Array => {
-    const textEncoder = new TextEncoder();
-    return textEncoder.encode(str);
+  StrToBuffer: (str: string): ?Uint8Array => {
+    if (TextEncoder) {
+      const textEncoder = new TextEncoder();
+      return textEncoder.encode(str);
+    }
+    return null;
   }
 };
 

--- a/src/parser/parser-utils.js
+++ b/src/parser/parser-utils.js
@@ -48,7 +48,7 @@ const XmlUtils = {
     }
     return parsedValue == null ? defaultValue : parsedValue;
   },
-  findElement: (node: HTMLElement, name: string): HTMLCollection<HTMLElement> => {
+  findElements: (node: HTMLElement, name: string): HTMLCollection<HTMLElement> => {
     return node.getElementsByTagName(name);
   },
   findChild(elem: HTMLElement, name: string): ?HTMLElement {

--- a/src/parser/parser-utils.js
+++ b/src/parser/parser-utils.js
@@ -11,13 +11,13 @@ const ParserUtils = {
 };
 
 const MpdUtils = {
-  TagsTypes: {
+  TagTypes: {
     SEGMENT_TEMPLATE: 'SegmentTemplate',
     REPRESENTATION: 'Representation',
     ESSENTIAL_PROPERTY: 'EssentialProperty',
     ADAPTATION_SET: 'AdaptationSet'
   },
-  AttributesTypes: {
+  AttributeTypes: {
     ID: 'id',
     CONTENT_TYPE: 'contentType',
     MIME_TYPE: 'mimeType',

--- a/src/parser/parser-utils.js
+++ b/src/parser/parser-utils.js
@@ -16,6 +16,22 @@ const MpdUtils = {
     REPRESENTATION: 'Representation',
     ESSENTIAL_PROPERTY: 'EssentialProperty',
     ADAPTATION_SET: 'AdaptationSet'
+  },
+  AttributesTypes: {
+    ID: 'id',
+    CONTENT_TYPE: 'contentType',
+    MIME_TYPE: 'mimeType',
+    MEDIA: 'media',
+    DURATION: 'duration',
+    START_NUMBER: 'startNumber',
+    TIMESCALE: 'timescale',
+    PRESENTATION_TIME_OFFSET: 'presentationTimeOffset',
+    END_NUMBER: 'endNumber',
+    BANDWIDTH: 'bandwidth',
+    WIDTH: 'width',
+    HEIGHT: 'height',
+    SCHEME_ID_URI: 'schemeIdUri',
+    VALUE: 'value'
   }
 };
 

--- a/src/parser/parser-utils.js
+++ b/src/parser/parser-utils.js
@@ -3,6 +3,10 @@ const ParserUtils = {
   BufferToStr: (buffer: ArrayBuffer): string => {
     const textDecoder = new TextDecoder();
     return textDecoder.decode(buffer);
+  },
+  StrToBuffer: (str: string): Uint8Array => {
+    const textEncoder = new TextEncoder();
+    return textEncoder.encode(str);
   }
 };
 

--- a/src/parser/parser-utils.js
+++ b/src/parser/parser-utils.js
@@ -1,0 +1,56 @@
+// @flow
+const ParserUtils = {
+  BufferToStr: (buffer: ArrayBuffer): string => {
+    const textDecoder = new TextDecoder();
+    return textDecoder.decode(buffer);
+  }
+};
+
+const MpdUtils = {
+  TagsTypes: {
+    SEGMENT_TEMPLATE: 'SegmentTemplate',
+    REPRESENTATION: 'Representation',
+    ESSENTIAL_PROPERTY: 'EssentialProperty',
+    ADAPTATION_SET: 'AdaptationSet'
+  }
+};
+
+const XmlUtils = {
+  parseXml: (text: string): Document => {
+    const domParser = new DOMParser();
+    return domParser.parseFromString(text, 'text/xml');
+  },
+  parseAttr: (elem: HTMLElement, name: string, parseFunction?: Function, defaultValue: any): any => {
+    let parsedValue = null;
+    const value = elem.getAttribute(name);
+    if (value !== null) {
+      parsedValue = parseFunction ? parseFunction(value) : value;
+    }
+    return parsedValue == null ? defaultValue : parsedValue;
+  },
+  findElement: (node: HTMLElement, name: string): HTMLCollection<HTMLElement> => {
+    return node.getElementsByTagName(name);
+  },
+  findChild(elem: HTMLElement, name: string): ?HTMLElement {
+    const children = this.findChildren(elem, name);
+    if (children.length !== 1) {
+      return null;
+    }
+    return children[0];
+  },
+  findChildren: (elem: HTMLElement, name: string): Array<HTMLElement> => {
+    return Array.from(elem.childNodes).filter(child => {
+      return child instanceof Element && child.tagName === name;
+    });
+  },
+  parsePositiveInt: (intString: string): ?number => {
+    const n = Number(intString);
+    return n % 1 === 0 && n > 0 ? n : null;
+  },
+  parseFloat: (floatString: string): ?number => {
+    const n = Number(floatString);
+    return !isNaN(n) ? n : null;
+  }
+};
+
+export {ParserUtils, MpdUtils, XmlUtils};

--- a/src/parser/representation.js
+++ b/src/parser/representation.js
@@ -1,0 +1,44 @@
+// @flow
+import {EssentialProperty} from './essential-property';
+import {XmlUtils, MpdUtils} from './parser-utils';
+
+class Representation {
+  _id: string;
+  _bandwidth: number;
+  _width: number;
+  _height: number;
+  _essentialProperty: EssentialProperty;
+
+  constructor(elem: HTMLElement) {
+    this._id = XmlUtils.parseAttr(elem, 'id');
+    this._bandwidth = XmlUtils.parseAttr(elem, 'bandwidth', parseInt);
+    this._width = XmlUtils.parseAttr(elem, 'width', parseInt);
+    this._height = XmlUtils.parseAttr(elem, 'height', parseInt);
+    const essPropElem = XmlUtils.findChild(elem, MpdUtils.TagsTypes.ESSENTIAL_PROPERTY);
+    if (essPropElem) {
+      this._essentialProperty = new EssentialProperty(essPropElem);
+    }
+  }
+
+  get bandwidth(): number {
+    return this._bandwidth;
+  }
+
+  get id(): string {
+    return this._id;
+  }
+
+  get width(): number {
+    return this._width;
+  }
+
+  get height(): number {
+    return this._height;
+  }
+
+  get essentialProperty(): EssentialProperty {
+    return this._essentialProperty;
+  }
+}
+
+export {Representation};

--- a/src/parser/representation.js
+++ b/src/parser/representation.js
@@ -1,6 +1,6 @@
 // @flow
 import {EssentialProperty} from './essential-property';
-import {XmlUtils, MpdUtils} from './parser-utils';
+import {MpdUtils, XmlUtils} from './parser-utils';
 
 class Representation {
   _id: string;

--- a/src/parser/representation.js
+++ b/src/parser/representation.js
@@ -7,7 +7,7 @@ class Representation {
   _bandwidth: number;
   _width: number;
   _height: number;
-  _essentialProperty: EssentialProperty;
+  _essentialProperty: ?EssentialProperty;
 
   constructor(elem: HTMLElement) {
     this._id = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.ID);
@@ -36,7 +36,7 @@ class Representation {
     return this._height;
   }
 
-  get essentialProperty(): EssentialProperty {
+  get essentialProperty(): ?EssentialProperty {
     return this._essentialProperty;
   }
 }

--- a/src/parser/representation.js
+++ b/src/parser/representation.js
@@ -10,11 +10,11 @@ class Representation {
   _essentialProperty: EssentialProperty;
 
   constructor(elem: HTMLElement) {
-    this._id = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.ID);
-    this._bandwidth = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.BANDWIDTH, parseInt);
-    this._width = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.WIDTH, parseInt);
-    this._height = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.HEIGHT, parseInt);
-    const essPropElem = XmlUtils.findChild(elem, MpdUtils.TagsTypes.ESSENTIAL_PROPERTY);
+    this._id = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.ID);
+    this._bandwidth = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.BANDWIDTH, parseInt);
+    this._width = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.WIDTH, parseInt);
+    this._height = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.HEIGHT, parseInt);
+    const essPropElem = XmlUtils.findChild(elem, MpdUtils.TagTypes.ESSENTIAL_PROPERTY);
     if (essPropElem) {
       this._essentialProperty = new EssentialProperty(essPropElem);
     }

--- a/src/parser/representation.js
+++ b/src/parser/representation.js
@@ -10,10 +10,10 @@ class Representation {
   _essentialProperty: EssentialProperty;
 
   constructor(elem: HTMLElement) {
-    this._id = XmlUtils.parseAttr(elem, 'id');
-    this._bandwidth = XmlUtils.parseAttr(elem, 'bandwidth', parseInt);
-    this._width = XmlUtils.parseAttr(elem, 'width', parseInt);
-    this._height = XmlUtils.parseAttr(elem, 'height', parseInt);
+    this._id = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.ID);
+    this._bandwidth = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.BANDWIDTH, parseInt);
+    this._width = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.WIDTH, parseInt);
+    this._height = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.HEIGHT, parseInt);
     const essPropElem = XmlUtils.findChild(elem, MpdUtils.TagsTypes.ESSENTIAL_PROPERTY);
     if (essPropElem) {
       this._essentialProperty = new EssentialProperty(essPropElem);

--- a/src/parser/segment-template.js
+++ b/src/parser/segment-template.js
@@ -2,6 +2,13 @@
 import {MpdUtils, XmlUtils} from './parser-utils';
 
 class SegmentTemplate {
+  static MediaTemplateType: {[key: string]: string} = {
+    REPRESENTATION: '$RepresentationID$',
+    NUMBER: '$Number$',
+    BANDWIDTH: '$Bandwidth$',
+    TIME: '$Time$'
+  };
+
   _media: string;
   _duration: number;
   _startNumber: number;

--- a/src/parser/segment-template.js
+++ b/src/parser/segment-template.js
@@ -1,5 +1,5 @@
 // @flow
-import {XmlUtils} from './parser-utils';
+import {MpdUtils, XmlUtils} from './parser-utils';
 
 class SegmentTemplate {
   _media: string;
@@ -11,12 +11,12 @@ class SegmentTemplate {
   _endNumber: number;
 
   constructor(elem: HTMLElement) {
-    this._media = XmlUtils.parseAttr(elem, 'media');
-    this._startNumber = XmlUtils.parseAttr(elem, 'startNumber', XmlUtils.parsePositiveInt);
-    this._duration = XmlUtils.parseAttr(elem, 'duration', XmlUtils.parseFloat);
-    this._timescale = XmlUtils.parseAttr(elem, 'timescale', XmlUtils.parsePositiveInt);
-    this._presentationTimeOffset = XmlUtils.parseAttr(elem, 'presentationTimeOffset', XmlUtils.parsePositiveInt);
-    this._endNumber = XmlUtils.parseAttr(elem, 'endNumber', XmlUtils.parsePositiveInt);
+    this._media = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.MEDIA);
+    this._startNumber = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.START_NUMBER, XmlUtils.parsePositiveInt);
+    this._duration = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.DURATION, XmlUtils.parseFloat);
+    this._timescale = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.TIMESCALE, XmlUtils.parsePositiveInt);
+    this._presentationTimeOffset = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.PRESENTATION_TIME_OFFSET, XmlUtils.parsePositiveInt);
+    this._endNumber = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.END_NUMBER, XmlUtils.parsePositiveInt);
   }
 
   get media(): string {

--- a/src/parser/segment-template.js
+++ b/src/parser/segment-template.js
@@ -5,7 +5,7 @@ class SegmentTemplate {
   _media: string;
   _duration: number;
   _startNumber: number;
-  // live related
+  // Live related
   _timescale: number;
   _presentationTimeOffset: number;
   _endNumber: number;

--- a/src/parser/segment-template.js
+++ b/src/parser/segment-template.js
@@ -11,12 +11,12 @@ class SegmentTemplate {
   _endNumber: number;
 
   constructor(elem: HTMLElement) {
-    this._media = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.MEDIA);
-    this._startNumber = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.START_NUMBER, XmlUtils.parsePositiveInt);
-    this._duration = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.DURATION, XmlUtils.parseFloat);
-    this._timescale = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.TIMESCALE, XmlUtils.parsePositiveInt);
-    this._presentationTimeOffset = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.PRESENTATION_TIME_OFFSET, XmlUtils.parsePositiveInt);
-    this._endNumber = XmlUtils.parseAttr(elem, MpdUtils.AttributesTypes.END_NUMBER, XmlUtils.parsePositiveInt);
+    this._media = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.MEDIA);
+    this._startNumber = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.START_NUMBER, XmlUtils.parsePositiveInt);
+    this._duration = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.DURATION, XmlUtils.parseFloat);
+    this._timescale = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.TIMESCALE, XmlUtils.parsePositiveInt);
+    this._presentationTimeOffset = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.PRESENTATION_TIME_OFFSET, XmlUtils.parsePositiveInt);
+    this._endNumber = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.END_NUMBER, XmlUtils.parsePositiveInt);
   }
 
   get media(): string {

--- a/src/parser/segment-template.js
+++ b/src/parser/segment-template.js
@@ -1,0 +1,47 @@
+// @flow
+import {XmlUtils} from './parser-utils';
+
+class SegmentTemplate {
+  _media: string;
+  _duration: number;
+  _startNumber: number;
+  // live related
+  _timescale: number;
+  _presentationTimeOffset: number;
+  _endNumber: number;
+
+  constructor(elem: HTMLElement) {
+    this._media = XmlUtils.parseAttr(elem, 'media');
+    this._startNumber = XmlUtils.parseAttr(elem, 'startNumber', XmlUtils.parsePositiveInt);
+    this._duration = XmlUtils.parseAttr(elem, 'duration', XmlUtils.parseFloat);
+    this._timescale = XmlUtils.parseAttr(elem, 'timescale', XmlUtils.parsePositiveInt);
+    this._presentationTimeOffset = XmlUtils.parseAttr(elem, 'presentationTimeOffset', XmlUtils.parsePositiveInt);
+    this._endNumber = XmlUtils.parseAttr(elem, 'endNumber', XmlUtils.parsePositiveInt);
+  }
+
+  get media(): string {
+    return this._media;
+  }
+
+  get startNumber(): number {
+    return this._startNumber;
+  }
+
+  get duration(): number {
+    return this._duration;
+  }
+
+  get timescale(): number {
+    return this._timescale;
+  }
+
+  get presentationTimeOffset(): number {
+    return this._presentationTimeOffset;
+  }
+
+  get endNumber(): number {
+    return this._endNumber;
+  }
+}
+
+export {SegmentTemplate};

--- a/test/src/parser/dash-manifest-parser.spec.js
+++ b/test/src/parser/dash-manifest-parser.spec.js
@@ -2,7 +2,11 @@ import {DashManifestParser} from '../../../src/parser/dash-manifest-parser';
 import {AdaptationSet} from '../../../src/parser/adaptation-set';
 import {SegmentTemplate} from '../../../src/parser/segment-template';
 import {EssentialProperty} from '../../../src/parser/essential-property';
-import {ImageAdaptationSetWithMultipleRepresentations, ImageAdaptationSetWithOneRepresentation} from './manifests';
+import {
+  ImageAdaptationSetWithMultipleRepresentations,
+  ImageAdaptationSetWithOneRepresentation,
+  ImageAdaptationWithEssentialUnderAdaptation
+} from './manifests';
 
 describe('DashManifestParser', () => {
   let manifestParser;
@@ -14,7 +18,7 @@ describe('DashManifestParser', () => {
 
     const imageSet = manifestParser.getAdaptationSet(AdaptationSet.ContentType.IMAGE);
     imageSet.should.be.an.instanceof(AdaptationSet);
-
+    (imageSet.essentialProperty === undefined).should.be.true;
     imageSet.id.should.equal('3');
     imageSet.contentType.should.equal(AdaptationSet.ContentType.IMAGE);
     imageSet.mimeType.should.equal('image/jpeg');
@@ -35,6 +39,7 @@ describe('DashManifestParser', () => {
     representation.height.should.equal(180);
 
     const {essentialProperty} = representation;
+    essentialProperty.should.be.exist;
     essentialProperty.should.be.an.instanceof(EssentialProperty);
     essentialProperty.schemeIdUri.should.equal('http://dashif.org/thumbnail_tile');
     essentialProperty.value.should.equal('10x1');
@@ -47,7 +52,7 @@ describe('DashManifestParser', () => {
 
     const imageSet = manifestParser.getAdaptationSet(AdaptationSet.ContentType.IMAGE);
     imageSet.should.be.an.instanceof(AdaptationSet);
-
+    (imageSet.essentialProperty === undefined).should.be.true;
     imageSet.id.should.equal('3');
     imageSet.contentType.should.equal(AdaptationSet.ContentType.IMAGE);
     imageSet.mimeType.should.equal('image/jpeg');
@@ -68,6 +73,7 @@ describe('DashManifestParser', () => {
     representation1.height.should.equal(1152);
 
     const essentialProperty1 = representation1.essentialProperty;
+    essentialProperty1.should.be.exist;
     essentialProperty1.should.be.an.instanceof(EssentialProperty);
     essentialProperty1.schemeIdUri.should.equal('http://dashif.org/thumbnail_tile');
     essentialProperty1.value.should.equal('10x20');
@@ -79,8 +85,42 @@ describe('DashManifestParser', () => {
     representation2.height.should.equal(1152);
 
     const essentialProperty2 = representation2.essentialProperty;
+    essentialProperty2.should.be.exist;
     essentialProperty2.should.be.an.instanceof(EssentialProperty);
     essentialProperty2.schemeIdUri.should.equal('http://dashif.org/thumbnail_tile');
     essentialProperty2.value.should.equal('8x8');
+  });
+
+  it('should parse successfully manifest with essential property under image adaptation', () => {
+    manifestParser = new DashManifestParser(ImageAdaptationWithEssentialUnderAdaptation);
+    manifestParser.parseManifest();
+    manifestParser.adaptationSets.should.have.lengthOf(1);
+
+    const imageSet = manifestParser.getAdaptationSet(AdaptationSet.ContentType.IMAGE);
+    imageSet.should.be.an.instanceof(AdaptationSet);
+    imageSet.id.should.equal('thumbnails');
+    imageSet.contentType.should.equal(AdaptationSet.ContentType.IMAGE);
+    imageSet.mimeType.should.equal('image/jpeg');
+
+    const {essentialProperty} = imageSet;
+    essentialProperty.should.be.exist;
+    essentialProperty.should.be.an.instanceof(EssentialProperty);
+    essentialProperty.schemeIdUri.should.equal('http://dashif.org/guidelines/thumbnails');
+    essentialProperty.value.should.equal('10');
+
+    const {segmentTemplate} = imageSet;
+    segmentTemplate.should.be.an.instanceof(SegmentTemplate);
+    segmentTemplate.media.should.equal('$RepresentationID$/thumb$Number$.jpg');
+    segmentTemplate.duration.should.equal(5);
+    segmentTemplate.startNumber.should.equal(1);
+    segmentTemplate.timescale.should.equal(1);
+
+    const {representations} = imageSet;
+    representations.should.have.lengthOf(1);
+
+    const representation = representations[0];
+    representation.id.should.equal('thumbnails_320x180');
+    representation.width.should.equal(320);
+    representation.height.should.equal(180);
   });
 });

--- a/test/src/parser/dash-manifest-parser.spec.js
+++ b/test/src/parser/dash-manifest-parser.spec.js
@@ -1,0 +1,86 @@
+import {DashManifestParser} from '../../../src/parser/dash-manifest-parser';
+import {AdaptationSet} from '../../../src/parser/adaptation-set';
+import {SegmentTemplate} from '../../../src/parser/segment-template';
+import {EssentialProperty} from '../../../src/parser/essential-property';
+import {ImageAdaptationSetWithMultipleRepresentations, ImageAdaptationSetWithOneRepresentation} from './manifests';
+
+describe('DashManifestParser', () => {
+  let manifestParser;
+
+  it('should parse successfully manifest with image adaptation set and one representation', () => {
+    manifestParser = new DashManifestParser(ImageAdaptationSetWithOneRepresentation);
+    manifestParser.parseManifest();
+    manifestParser.adaptationSets.should.have.lengthOf(1);
+
+    const imageSet = manifestParser.getAdaptationSet(AdaptationSet.ContentType.IMAGE);
+    imageSet.should.be.an.instanceof(AdaptationSet);
+
+    imageSet.id.should.equal('3');
+    imageSet.contentType.should.equal(AdaptationSet.ContentType.IMAGE);
+    imageSet.mimeType.should.equal('image/jpeg');
+
+    const {segmentTemplate} = imageSet;
+    segmentTemplate.should.be.an.instanceof(SegmentTemplate);
+    segmentTemplate.media.should.equal('$RepresentationID$/tile_$Number$.jpg');
+    segmentTemplate.duration.should.equal(100);
+    segmentTemplate.startNumber.should.equal(1);
+
+    const {representations} = imageSet;
+    representations.should.have.lengthOf(1);
+
+    const representation = representations[0];
+    representation.bandwidth.should.equal(12288);
+    representation.id.should.equal('thumbnails_320x180');
+    representation.width.should.equal(3200);
+    representation.height.should.equal(180);
+
+    const {essentialProperty} = representation;
+    essentialProperty.should.be.an.instanceof(EssentialProperty);
+    essentialProperty.schemeIdUri.should.equal('http://dashif.org/thumbnail_tile');
+    essentialProperty.value.should.equal('10x1');
+  });
+
+  it('should parse successfully manifest with image adaptation set and multiple representation', () => {
+    manifestParser = new DashManifestParser(ImageAdaptationSetWithMultipleRepresentations);
+    manifestParser.parseManifest();
+    manifestParser.adaptationSets.should.have.lengthOf(1);
+
+    const imageSet = manifestParser.getAdaptationSet(AdaptationSet.ContentType.IMAGE);
+    imageSet.should.be.an.instanceof(AdaptationSet);
+
+    imageSet.id.should.equal('3');
+    imageSet.contentType.should.equal(AdaptationSet.ContentType.IMAGE);
+    imageSet.mimeType.should.equal('image/jpeg');
+
+    const {segmentTemplate} = imageSet;
+    segmentTemplate.should.be.an.instanceof(SegmentTemplate);
+    segmentTemplate.media.should.equal('$RepresentationID$/tile_$Number$.jpg');
+    segmentTemplate.duration.should.equal(634.566);
+    segmentTemplate.startNumber.should.equal(1);
+
+    const {representations} = imageSet;
+    representations.should.have.lengthOf(2);
+
+    const representation1 = representations[0];
+    representation1.bandwidth.should.equal(12000);
+    representation1.id.should.equal('thumbnails_102x58');
+    representation1.width.should.equal(1024);
+    representation1.height.should.equal(1152);
+
+    const essentialProperty1 = representation1.essentialProperty;
+    essentialProperty1.should.be.an.instanceof(EssentialProperty);
+    essentialProperty1.schemeIdUri.should.equal('http://dashif.org/thumbnail_tile');
+    essentialProperty1.value.should.equal('10x20');
+
+    const representation2 = representations[1];
+    representation2.bandwidth.should.equal(24000);
+    representation2.id.should.equal('thumbnails_256x144');
+    representation2.width.should.equal(2048);
+    representation2.height.should.equal(1152);
+
+    const essentialProperty2 = representation2.essentialProperty;
+    essentialProperty2.should.be.an.instanceof(EssentialProperty);
+    essentialProperty2.schemeIdUri.should.equal('http://dashif.org/thumbnail_tile');
+    essentialProperty2.value.should.equal('8x8');
+  });
+});

--- a/test/src/parser/manifests.js
+++ b/test/src/parser/manifests.js
@@ -73,4 +73,39 @@ const ImageAdaptationSetWithMultipleRepresentations = ParserUtils.StrToBuffer(`
 </MPD>
   `);
 
-export {ImageAdaptationSetWithOneRepresentation, ImageAdaptationSetWithMultipleRepresentations};
+const ImageAdaptationWithEssentialUnderAdaptation = ParserUtils.StrToBuffer(`
+<MPD mediaPresentationDuration="PT634.566S" minBufferTime="PT2.00S" profiles="urn:hbbtv:dash:profile:isoff-live:2012,urn:mpeg:dash:profile:isoff-live:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd">
+    <BaseURL>./</BaseURL>
+    <Period>
+        <AdaptationSet mimeType="video/mp4" contentType="video" subsegmentAlignment="true" subsegmentStartsWithSAP="1" par="16:9">
+            <SegmentTemplate duration="120" timescale="30" media="$RepresentationID$/$RepresentationID$_$Number$.m4v" startNumber="1" initialization="$RepresentationID$/$RepresentationID$_0.m4v"/>
+            <Representation id="bbb_30fps_1024x576_2500k" codecs="avc1.64001f" bandwidth="3134488" width="1024" height="576" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_1280x720_4000k" codecs="avc1.64001f" bandwidth="4952892" width="1280" height="720" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_1920x1080_8000k" codecs="avc1.640028" bandwidth="9914554" width="1920" height="1080" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_320x180_200k" codecs="avc1.64000d" bandwidth="254320" width="320" height="180" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_320x180_400k" codecs="avc1.64000d" bandwidth="507246" width="320" height="180" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_480x270_600k" codecs="avc1.640015" bandwidth="759798" width="480" height="270" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_640x360_1000k" codecs="avc1.64001e" bandwidth="1254758" width="640" height="360" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_640x360_800k" codecs="avc1.64001e" bandwidth="1013310" width="640" height="360" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_768x432_1500k" codecs="avc1.64001e" bandwidth="1883700" width="768" height="432" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_3840x2160_12000k" codecs="avc1.640033" bandwidth="14931538" width="3840" height="2160" frameRate="30" sar="1:1" scanType="progressive"/>
+        </AdaptationSet>
+        <AdaptationSet mimeType="audio/mp4" contentType="audio" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+            <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value="6"/>
+            <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+            <SegmentTemplate duration="192512" timescale="48000" media="$RepresentationID$/$RepresentationID$_$Number$.m4a" startNumber="1" initialization="$RepresentationID$/$RepresentationID$_0.m4a"/>
+            <Representation id="bbb_a64k" codecs="mp4a.40.5" bandwidth="67071" audioSamplingRate="48000">
+                <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet id="thumbnails" mimeType="image/jpeg" contentType="image">
+            <EssentialProperty schemeIdUri="http://dashif.org/guidelines/thumbnails" value="10" />
+            <SegmentTemplate media="$RepresentationID$/thumb$Number$.jpg" timescale="1" duration="5" startNumber="1"/>
+            <Representation id="thumbnails_320x180" width="320" height="180" frameRate="1/5">
+    </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>
+`);
+
+export {ImageAdaptationSetWithOneRepresentation, ImageAdaptationSetWithMultipleRepresentations, ImageAdaptationWithEssentialUnderAdaptation};

--- a/test/src/parser/manifests.js
+++ b/test/src/parser/manifests.js
@@ -1,0 +1,76 @@
+import {ParserUtils} from '../../../src/parser/parser-utils';
+
+const ImageAdaptationSetWithOneRepresentation = ParserUtils.StrToBuffer(`
+  <MPD mediaPresentationDuration="PT634.566S" minBufferTime="PT2.00S" profiles="urn:hbbtv:dash:profile:isoff-live:2012,urn:mpeg:dash:profile:isoff-live:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd">
+ <BaseURL>./</BaseURL>
+ <Period>
+  <AdaptationSet id="1" mimeType="video/mp4" contentType="video" subsegmentAlignment="true" subsegmentStartsWithSAP="1" par="16:9">
+   <SegmentTemplate duration="120" timescale="30" media="$RepresentationID$/$RepresentationID$_$Number$.m4v" startNumber="1" initialization="$RepresentationID$/$RepresentationID$_0.m4v"/>
+   <Representation id="bbb_30fps_1024x576_2500k" codecs="avc1.64001f" bandwidth="3134488" width="1024" height="576" frameRate="30" sar="1:1" scanType="progressive"/>
+   <Representation id="bbb_30fps_1280x720_4000k" codecs="avc1.64001f" bandwidth="4952892" width="1280" height="720" frameRate="30" sar="1:1" scanType="progressive"/>
+   <Representation id="bbb_30fps_1920x1080_8000k" codecs="avc1.640028" bandwidth="9914554" width="1920" height="1080" frameRate="30" sar="1:1" scanType="progressive"/>
+   <Representation id="bbb_30fps_320x180_200k" codecs="avc1.64000d" bandwidth="254320" width="320" height="180" frameRate="30" sar="1:1" scanType="progressive"/>
+   <Representation id="bbb_30fps_320x180_400k" codecs="avc1.64000d" bandwidth="507246" width="320" height="180" frameRate="30" sar="1:1" scanType="progressive"/>
+   <Representation id="bbb_30fps_480x270_600k" codecs="avc1.640015" bandwidth="759798" width="480" height="270" frameRate="30" sar="1:1" scanType="progressive"/>
+   <Representation id="bbb_30fps_640x360_1000k" codecs="avc1.64001e" bandwidth="1254758" width="640" height="360" frameRate="30" sar="1:1" scanType="progressive"/>
+   <Representation id="bbb_30fps_640x360_800k" codecs="avc1.64001e" bandwidth="1013310" width="640" height="360" frameRate="30" sar="1:1" scanType="progressive"/>
+   <Representation id="bbb_30fps_768x432_1500k" codecs="avc1.64001e" bandwidth="1883700" width="768" height="432" frameRate="30" sar="1:1" scanType="progressive"/>
+   <Representation id="bbb_30fps_3840x2160_12000k" codecs="avc1.640033" bandwidth="14931538" width="3840" height="2160" frameRate="30" sar="1:1" scanType="progressive"/>
+  </AdaptationSet>
+  <AdaptationSet id="2" mimeType="audio/mp4" contentType="audio" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+   <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value="6"/>
+   <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+   <SegmentTemplate duration="192512" timescale="48000" media="$RepresentationID$/$RepresentationID$_$Number$.m4a" startNumber="1" initialization="$RepresentationID$/$RepresentationID$_0.m4a"/>
+   <Representation id="bbb_a64k" codecs="mp4a.40.5" bandwidth="67071" audioSamplingRate="48000">
+    <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+   </Representation>
+  </AdaptationSet>
+  <AdaptationSet id="3" mimeType="image/jpeg" contentType="image">
+    <SegmentTemplate media="$RepresentationID$/tile_$Number$.jpg" duration="100" startNumber="1"/>
+    <Representation bandwidth="12288" id="thumbnails_320x180" width="3200" height="180">
+      <EssentialProperty schemeIdUri="http://dashif.org/thumbnail_tile" value="10x1"/>
+    </Representation>
+  </AdaptationSet>
+ </Period>
+</MPD>
+  `);
+
+const ImageAdaptationSetWithMultipleRepresentations = ParserUtils.StrToBuffer(`
+ <MPD mediaPresentationDuration="PT634.566S" minBufferTime="PT2.00S" profiles="urn:hbbtv:dash:profile:isoff-live:2012,urn:mpeg:dash:profile:isoff-live:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd">
+    <BaseURL>./</BaseURL>
+    <Period>
+        <AdaptationSet id="1" mimeType="video/mp4" contentType="video" subsegmentAlignment="true" subsegmentStartsWithSAP="1" par="16:9">
+            <SegmentTemplate duration="120" timescale="30" media="$RepresentationID$/$RepresentationID$_$Number$.m4v" startNumber="1" initialization="$RepresentationID$/$RepresentationID$_0.m4v"/>
+            <Representation id="bbb_30fps_1024x576_2500k" codecs="avc1.64001f" bandwidth="3134488" width="1024" height="576" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_1280x720_4000k" codecs="avc1.64001f" bandwidth="4952892" width="1280" height="720" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_1920x1080_8000k" codecs="avc1.640028" bandwidth="9914554" width="1920" height="1080" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_320x180_200k" codecs="avc1.64000d" bandwidth="254320" width="320" height="180" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_320x180_400k" codecs="avc1.64000d" bandwidth="507246" width="320" height="180" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_480x270_600k" codecs="avc1.640015" bandwidth="759798" width="480" height="270" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_640x360_1000k" codecs="avc1.64001e" bandwidth="1254758" width="640" height="360" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_640x360_800k" codecs="avc1.64001e" bandwidth="1013310" width="640" height="360" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_768x432_1500k" codecs="avc1.64001e" bandwidth="1883700" width="768" height="432" frameRate="30" sar="1:1" scanType="progressive"/>
+            <Representation id="bbb_30fps_3840x2160_12000k" codecs="avc1.640033" bandwidth="14931538" width="3840" height="2160" frameRate="30" sar="1:1" scanType="progressive"/>
+        </AdaptationSet>
+        <AdaptationSet id="2" mimeType="audio/mp4" contentType="audio" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+            <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value="6"/>
+            <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+            <SegmentTemplate duration="192512" timescale="48000" media="$RepresentationID$/$RepresentationID$_$Number$.m4a" startNumber="1" initialization="$RepresentationID$/$RepresentationID$_0.m4a"/>
+            <Representation id="bbb_a64k" codecs="mp4a.40.5" bandwidth="67071" audioSamplingRate="48000">
+                <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet id="3" mimeType="image/jpeg" contentType="image">
+            <SegmentTemplate media="$RepresentationID$/tile_$Number$.jpg" duration="634.566" startNumber="1"/>
+            <Representation bandwidth="12000" id="thumbnails_102x58" width="1024" height="1152">
+                <EssentialProperty schemeIdUri="http://dashif.org/thumbnail_tile" value="10x20"/>
+            </Representation>
+            <Representation bandwidth="24000" id="thumbnails_256x144" width="2048" height="1152">
+                <EssentialProperty schemeIdUri="http://dashif.org/thumbnail_tile" value="8x8"/>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>
+  `);
+
+export {ImageAdaptationSetWithOneRepresentation, ImageAdaptationSetWithMultipleRepresentations};


### PR DESCRIPTION

### Description of the Changes

Shaka player does not support parsing of image type adaptation set, so need to create our own dedicated parser for this.
We will register to the response filter and extract the image tracks data in the following raw structure:

- AdaptationSet
    - ?EssentialProperty
    - SegmentTemplate
    - List<Representation>
      - ?EssentialProperty

See diagram for better understanding of the flow:

![DashManifestParser flow (1)](https://user-images.githubusercontent.com/21081590/107186164-6bfeef80-69ec-11eb-9ce5-e9e2e5de1713.png)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/playkit-js-dash/131)
<!-- Reviewable:end -->
