### PR TITLE
feat(FEC-10768): expose in-stream DASH thumbnails

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-flow": "^7.10.4",
     "@babel/register": "^7.10.5",
-    "@playkit-js/playkit-js": "0.65.0",
+    "@playkit-js/playkit-js": "0.68.0-canary.3b1d78e",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-istanbul": "^6.0.0",
@@ -104,7 +104,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "0.65.0",
+    "@playkit-js/playkit-js": "0.68.0-canary.3b1d78e",
     "shaka-player": "3.0.8"
   },
   "publishConfig": {

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1098,7 +1098,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       DashAdapter._logger.error(error);
       // Stop all adapter processes on critical error
       if (error.severity === Error.Severity.CRITICAL) {
-        return this.destroy();
+        this.destroy();
       }
     }
   }

--- a/src/dash-thumbnail-controller.js
+++ b/src/dash-thumbnail-controller.js
@@ -30,18 +30,18 @@ class DashThumbnailController {
   }
 
   getThumbnail(time: number): ThumbnailInfo {
-    const thumbnailInfo = new ThumbnailInfo();
     const activeTrack = this.getActiveTrack();
     const {duration, rows, cols, sliceWidth, sliceHeight, customData} = activeTrack;
     const page = Math.floor(time / duration) + customData.startNumber;
     const offset = time % duration;
     const thumbIndex = Math.floor((offset * rows * cols) / duration);
-    thumbnailInfo.width = Math.floor(sliceWidth);
-    thumbnailInfo.height = Math.floor(sliceHeight);
-    thumbnailInfo.x = Math.floor(thumbIndex % rows) * sliceWidth;
-    thumbnailInfo.y = Math.floor(thumbIndex / rows) * sliceHeight;
-    thumbnailInfo.url = this._buildUrlFromTemplate(activeTrack, page);
-    return thumbnailInfo;
+    return new ThumbnailInfo({
+      width: Math.floor(sliceWidth),
+      height: Math.floor(sliceHeight),
+      x: Math.floor(thumbIndex % rows) * sliceWidth,
+      y: Math.floor(thumbIndex / rows) * sliceHeight,
+      url: this._buildUrlFromTemplate(activeTrack, page)
+    });
   }
 
   _parseTracks = (set: AdaptationSet, playerUrl: string): void => {

--- a/src/dash-thumbnail-controller.js
+++ b/src/dash-thumbnail-controller.js
@@ -1,0 +1,107 @@
+// @flow
+import {AdaptationSet} from './parser/adaptation-set';
+import {Representation} from './parser/representation';
+import {UrlUtils} from './parser/parser-utils';
+import {ImageTrack, ThumbnailInfo} from '@playkit-js/playkit-js';
+import {EssentialProperty} from './parser/essential-property';
+
+class DashThumbnailController {
+  _tracks: Array<ImageTrack> = [];
+
+  constructor(set: AdaptationSet, playerUrl: string) {
+    this._parseTracks(set, playerUrl);
+    if (this._tracks.length > 0) {
+      this._tracks.sort((t1: ImageTrack, t2: ImageTrack) => t1.customData.bitrate - t2.customData.bitrate);
+      this.selectTrack(this._tracks[this._tracks.length - 1]);
+    }
+  }
+
+  selectTrack(track: ImageTrack): void {
+    this._tracks.forEach((t: ImageTrack) => (t.active = false));
+    track.active = true;
+  }
+
+  getTracks(): Array<ImageTrack> {
+    return this._tracks;
+  }
+
+  getActiveTrack(): ImageTrack {
+    return this._tracks.find((t: ImageTrack) => t.active);
+  }
+
+  getThumbnail(time: number): ThumbnailInfo {
+    const thumbnailInfo = new ThumbnailInfo();
+    const activeTrack = this.getActiveTrack();
+    const {duration, rows, cols, sliceWidth, sliceHeight, customData} = activeTrack;
+    const page = Math.floor(time / duration) + customData.startNumber;
+    const offset = time % duration;
+    const thumbIndex = Math.floor((offset * rows * cols) / duration);
+    thumbnailInfo.width = Math.floor(sliceWidth);
+    thumbnailInfo.height = Math.floor(sliceHeight);
+    thumbnailInfo.x = Math.floor(thumbIndex % rows) * sliceWidth;
+    thumbnailInfo.y = Math.floor(thumbIndex / rows) * sliceHeight;
+    thumbnailInfo.url = this._buildUrlFromTemplate(activeTrack, page);
+    return thumbnailInfo;
+  }
+
+  _parseTracks = (set: AdaptationSet, playerUrl: string): void => {
+    const {representations, segmentTemplate, essentialProperty} = set;
+    representations.forEach((representation: Representation, index: number) => {
+      const {id, bandwidth, width, height} = representation;
+      const {startNumber, duration, media, timescale, presentationTimeOffset} = segmentTemplate;
+      const value = this._getEssentialValue(essentialProperty, representation);
+      const [rows, cols] = this._getDimensions(value);
+      this._tracks.push(
+        new ImageTrack({
+          id,
+          index,
+          active: false,
+          width,
+          height,
+          duration,
+          rows,
+          cols,
+          url: this._buildTemplateUrl(media, id, playerUrl),
+          customData: {
+            bitrate: bandwidth,
+            startNumber,
+            timescale,
+            presentationTimeOffset
+          }
+        })
+      );
+    });
+  };
+
+  _getDimensions = (value: string): Array<number> => {
+    let rows = 1,
+      cols = 1;
+    if (value.includes('x')) {
+      const values = value.split('x');
+      rows = parseInt(values[0]);
+      cols = parseInt(values[1]);
+    }
+    return [rows, cols];
+  };
+
+  _getEssentialValue = (essentialProperty: ?EssentialProperty, representation: Representation): string => {
+    return essentialProperty ? essentialProperty.value : representation.essentialProperty ? representation.essentialProperty.value : '';
+  };
+
+  _buildTemplateUrl = (mediaTemplate: string, id: string, url: string): string => {
+    const last = url.split('/').pop();
+    const baseUrl = url.replace(last, '');
+    const urlTemplate = `${baseUrl}${mediaTemplate}`;
+    return UrlUtils.resolve(urlTemplate, {id});
+  };
+
+  _buildUrlFromTemplate = (track: ImageTrack, index: number): string => {
+    return UrlUtils.resolve(track.url, {
+      index,
+      time: (index - 1) * track.duration * track.customData.timescale,
+      bitrate: track.customData.bitrate
+    });
+  };
+}
+
+export {DashThumbnailController};

--- a/src/parser/dash-manifest-parser.js
+++ b/src/parser/dash-manifest-parser.js
@@ -12,10 +12,15 @@ class DashManifestParser {
     return window.TextEncoder && window.TextDecoder;
   }
 
-  constructor(manifest: ArrayBuffer) {
+  constructor(manifest: ArrayBuffer | string) {
     this._logger.debug('Initialize manifest parser');
     this._adaptationSets = [];
-    const xmlStr = ParserUtils.BufferToStr(manifest);
+    let xmlStr;
+    if (manifest instanceof ArrayBuffer) {
+      xmlStr = ParserUtils.BufferToStr(manifest);
+    } else {
+      xmlStr = manifest;
+    }
     if (xmlStr) {
       this._xmlDoc = XmlUtils.parseXml(xmlStr);
     }
@@ -32,8 +37,16 @@ class DashManifestParser {
     }
   }
 
-  getAdaptationSet(type: string): ?AdaptationSet {
-    return this._adaptationSets.find((adaptationSet: AdaptationSet) => adaptationSet.contentType === type);
+  getImageSet(): ?AdaptationSet {
+    return this._adaptationSets.find((adaptationSet: AdaptationSet) => adaptationSet.contentType === AdaptationSet.ContentType.IMAGE);
+  }
+
+  hasImageSet(): boolean {
+    return !!this.getImageSet();
+  }
+
+  get adaptationSets(): Array<AdaptationSet> {
+    return this._adaptationSets;
   }
 
   _parseAdaptionSets = () => {
@@ -49,10 +62,6 @@ class DashManifestParser {
       this._logger.debug('No image adaptations were found in manifest');
     }
   };
-
-  get adaptationSets(): Array<AdaptationSet> {
-    return this._adaptationSets;
-  }
 }
 
 export {DashManifestParser};

--- a/src/parser/parser-utils.js
+++ b/src/parser/parser-utils.js
@@ -1,4 +1,34 @@
 // @flow
+import {SegmentTemplate} from './segment-template';
+
+const UrlUtils = {
+  resolve: (url: string, data: {id?: string, index?: number, bitrate?: number, time?: number}): string => {
+    const {id, index, bitrate, time} = data;
+    const regExp = /\$([a-zA-Z]+)\$/g;
+    const expressions = url.match(regExp);
+    const replaceTokens = (url: string, exp: string, token: any) => (token ? url.replace(exp, token) : url);
+    if (expressions) {
+      expressions.forEach((exp: string) => {
+        switch (exp) {
+          case SegmentTemplate.MediaTemplateType.REPRESENTATION:
+            url = replaceTokens(url, exp, id);
+            break;
+          case SegmentTemplate.MediaTemplateType.NUMBER:
+            url = replaceTokens(url, exp, index);
+            break;
+          case SegmentTemplate.MediaTemplateType.BANDWIDTH:
+            url = replaceTokens(url, exp, bitrate);
+            break;
+          case SegmentTemplate.MediaTemplateType.TIME:
+            url = replaceTokens(url, exp, time);
+            break;
+        }
+      });
+    }
+    return url;
+  }
+};
+
 const ParserUtils = {
   BufferToStr: (buffer: ArrayBuffer): ?string => {
     if (TextDecoder) {
@@ -69,6 +99,10 @@ const XmlUtils = {
       return child instanceof Element && child.tagName === name;
     });
   },
+  parseInt: (intString: string): ?number => {
+    const n = Number(intString);
+    return n % 1 === 0 ? n : null;
+  },
   parsePositiveInt: (intString: string): ?number => {
     const n = Number(intString);
     return n % 1 === 0 && n > 0 ? n : null;
@@ -79,4 +113,4 @@ const XmlUtils = {
   }
 };
 
-export {ParserUtils, MpdUtils, XmlUtils};
+export {ParserUtils, MpdUtils, XmlUtils, UrlUtils};

--- a/src/parser/segment-template.js
+++ b/src/parser/segment-template.js
@@ -19,10 +19,10 @@ class SegmentTemplate {
 
   constructor(elem: HTMLElement) {
     this._media = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.MEDIA);
-    this._startNumber = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.START_NUMBER, XmlUtils.parsePositiveInt);
+    this._startNumber = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.START_NUMBER, XmlUtils.parseInt, 1);
     this._duration = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.DURATION, XmlUtils.parseFloat);
-    this._timescale = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.TIMESCALE, XmlUtils.parsePositiveInt);
-    this._presentationTimeOffset = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.PRESENTATION_TIME_OFFSET, XmlUtils.parsePositiveInt);
+    this._timescale = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.TIMESCALE, XmlUtils.parsePositiveInt, 1);
+    this._presentationTimeOffset = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.PRESENTATION_TIME_OFFSET, XmlUtils.parseInt, 0);
     this._endNumber = XmlUtils.parseAttr(elem, MpdUtils.AttributeTypes.END_NUMBER, XmlUtils.parsePositiveInt);
   }
 

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -5,22 +5,34 @@ import {Widevine} from '../../src/drm/widevine';
 import {PlayReady} from '../../src/drm/playready';
 import {wwDrmData, prDrmData} from './drm/fake-drm-data';
 import shaka from 'shaka-player';
+import {ImageTrack, ThumbnailInfo} from '@playkit-js/playkit-js/dist/playkit';
+
 const targetId = 'player-placeholder_dash-adapter.spec';
 
-let vodSource = {
+const vodSource = {
   mimetype: 'application/dash+xml',
   url:
     'https://cfvod.kaltura.com/dasha/p/1740481/sp/174048100/serveFlavor/entryId/1_ez6mf1n8/v/,1/ev/3/flavorId/1_fwvuvqym,1/ev/3/flavorId/1_5zyuykzo,1/ev/3/flavorId/1_4xul4cg0,1/ev/3/flavorId/1_5jovgwnt,1/ev/3/flavorId/1_dt7bjb0q,2/ev/3/flavorId/0_og64h1z3,2/ev/3/flavorId/0_mgociiko,2/ev/3/flavorId/0_dxxbalt0,/forceproxy/true/name/a.mp4.urlset/manifest.mpd'
 };
 
-let liveSource = {
+const liveSource = {
   mimetype: 'application/dash+xml',
   url: 'http://wowzaec2demo.streamlock.net/live/bigbuckbunny/manifest_mpm4sav_mvtime.mpd'
 };
 
-let dvrSource = {
+const dvrSource = {
   mimetype: 'application/dash+xml',
   url: 'http://klive-a.akamaihd.net/dc-1/live/dash/p/1897241/e/1_gffgxm38/t/e83cor13pmTGTQ7kPZiopg/manifest.mpd'
+};
+
+const vodInStreamThumbnailSource = {
+  mimetype: 'application/dash+xml',
+  url: 'http://dash.edgesuite.net/akamai/bbb_30fps/bbb_with_multiple_tiled_thumbnails.mpd'
+};
+
+const dvrInStreamThumbnailSource = {
+  mimetype: 'application/dash+xml',
+  url: 'http://pf5.broadpeak-vcdn.com/bpk-tv/tvr/default/index.mpd'
 };
 
 describe.skip('DashAdapter [debugging and testing manually]', () => {
@@ -244,7 +256,14 @@ describe('DashAdapter: load', () => {
   });
 
   it('should fail load if URL is corrupted/return 403', done => {
-    dashInstance = DashAdapter.createAdapter(video, {mimetype: 'application/dash+xml', url: 'some/corrupted/url'}, config);
+    dashInstance = DashAdapter.createAdapter(
+      video,
+      {
+        mimetype: 'application/dash+xml',
+        url: 'some/corrupted/url'
+      },
+      config
+    );
 
     dashInstance.load().catch(error => {
       error.should.be.exist;
@@ -1736,5 +1755,114 @@ describe('DashAdapter: response filter', () => {
         done(e);
       }
     });
+  });
+});
+
+describe('DashAdapter: in-stream thumbnails', () => {
+  let video, dashInstance, config;
+
+  beforeEach(() => {
+    video = document.createElement('video');
+    config = {playback: {options: {html5: {dash: {}}}}};
+  });
+
+  afterEach(done => {
+    dashInstance.destroy().then(() => {
+      dashInstance = null;
+      done();
+    });
+  });
+
+  after(() => {
+    TestUtils.removeVideoElementsFromTestPage();
+  });
+
+  it('should load vod stream successfully', done => {
+    dashInstance = DashAdapter.createAdapter(video, vodInStreamThumbnailSource, config);
+    dashInstance
+      .load()
+      .then(result => {
+        try {
+          dashInstance._shaka.should.exist;
+          dashInstance._config.should.exist;
+          dashInstance._videoElement.should.exist;
+          dashInstance._sourceObj.should.exist;
+          dashInstance._manifestParser.should.exist;
+          dashInstance._thumbnailController.should.exist;
+          result.tracks.filter(t => t instanceof ImageTrack).should.have.lengthOf(2);
+          dashInstance._manifestParser.hasImageSet().should.be.true;
+          dashInstance._manifestParser.getImageSet().should.exist;
+          dashInstance._manifestParser._adaptationSets.should.have.lengthOf(1);
+          dashInstance._thumbnailController.getTracks().should.have.lengthOf(2);
+          dashInstance.getThumbnail(1000).should.be.instanceOf(ThumbnailInfo);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      })
+      .catch(done);
+  });
+
+  it('should load dvr stream successfully', done => {
+    dashInstance = DashAdapter.createAdapter(video, dvrInStreamThumbnailSource, config);
+    dashInstance
+      .load()
+      .then(result => {
+        try {
+          dashInstance._shaka.should.exist;
+          dashInstance._config.should.exist;
+          dashInstance._videoElement.should.exist;
+          dashInstance._sourceObj.should.exist;
+          dashInstance._manifestParser.should.exist;
+          dashInstance._thumbnailController.should.exist;
+          result.tracks.filter(t => t instanceof ImageTrack).should.have.lengthOf(1);
+          dashInstance._manifestParser.hasImageSet().should.be.true;
+          dashInstance._manifestParser.getImageSet().should.exist;
+          dashInstance._manifestParser._adaptationSets.should.have.lengthOf(1);
+          dashInstance._thumbnailController.getTracks().should.have.lengthOf(1);
+          dashInstance.getThumbnail(1000).should.be.instanceOf(ThumbnailInfo);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      })
+      .catch(done);
+  });
+
+  it('should refresh dvr manifest successfully', done => {
+    let refreshCount = 0;
+    const targetRefreshCount = 3;
+    dashInstance = DashAdapter.createAdapter(video, dvrInStreamThumbnailSource, config);
+    dashInstance.addEventListener(EventType.TRACKS_CHANGED, event => {
+      refreshCount++;
+      event.payload.tracks.should.have.lengthOf(3);
+      event.payload.tracks.filter(t => t instanceof ImageTrack).should.have.lengthOf(1);
+      if (refreshCount === targetRefreshCount) {
+        done();
+      }
+    });
+    dashInstance.load().catch(done);
+  });
+
+  it('should disable parser for dvr stream when no image tracks in stream', done => {
+    dashInstance = DashAdapter.createAdapter(video, liveSource, config);
+    dashInstance
+      .load()
+      .then(() => {
+        try {
+          dashInstance._isParserDisabled.should.be.false;
+          dashInstance._shaka.getNetworkingEngine().registerResponseFilter(type => {
+            switch (type) {
+              case shaka.net.NetworkingEngine.RequestType.MANIFEST:
+                dashInstance._isParserDisabled.should.be.true;
+                done();
+                break;
+            }
+          });
+        } catch (e) {
+          done(e);
+        }
+      })
+      .catch(done);
   });
 });

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -1828,41 +1828,4 @@ describe('DashAdapter: in-stream thumbnails', () => {
       })
       .catch(done);
   });
-
-  it('should refresh dvr manifest successfully', done => {
-    let refreshCount = 0;
-    const targetRefreshCount = 3;
-    dashInstance = DashAdapter.createAdapter(video, dvrInStreamThumbnailSource, config);
-    dashInstance.addEventListener(EventType.TRACKS_CHANGED, event => {
-      refreshCount++;
-      event.payload.tracks.should.have.lengthOf(3);
-      event.payload.tracks.filter(t => t instanceof ImageTrack).should.have.lengthOf(1);
-      if (refreshCount === targetRefreshCount) {
-        done();
-      }
-    });
-    dashInstance.load().catch(done);
-  });
-
-  it('should disable parser for dvr stream when no image tracks in stream', done => {
-    dashInstance = DashAdapter.createAdapter(video, liveSource, config);
-    dashInstance
-      .load()
-      .then(() => {
-        try {
-          dashInstance._isParserDisabled.should.be.false;
-          dashInstance._shaka.getNetworkingEngine().registerResponseFilter(type => {
-            switch (type) {
-              case shaka.net.NetworkingEngine.RequestType.MANIFEST:
-                dashInstance._isParserDisabled.should.be.true;
-                done();
-                break;
-            }
-          });
-        } catch (e) {
-          done(e);
-        }
-      })
-      .catch(done);
-  });
 });

--- a/test/src/dash-thumbnail-controller.spec.js
+++ b/test/src/dash-thumbnail-controller.spec.js
@@ -1,7 +1,7 @@
 import {DashManifestParser} from '../../src/parser/dash-manifest-parser';
 import {ImageAdaptationSetWithMultipleRepresentations, ImageAdaptationSetWithOneRepresentation} from './parser/manifests';
 import {DashThumbnailController} from '../../src/dash-thumbnail-controller';
-import {ImageTrack} from '@playkit-js/playkit-js/dist/playkit';
+import {ImageTrack} from '@playkit-js/playkit-js';
 
 describe('DashThumbnailController', () => {
   let thumbnailController, manifestParser;

--- a/test/src/dash-thumbnail-controller.spec.js
+++ b/test/src/dash-thumbnail-controller.spec.js
@@ -1,0 +1,153 @@
+import {DashManifestParser} from '../../src/parser/dash-manifest-parser';
+import {ImageAdaptationSetWithMultipleRepresentations, ImageAdaptationSetWithOneRepresentation} from './parser/manifests';
+import {DashThumbnailController} from '../../src/dash-thumbnail-controller';
+import {ImageTrack} from '@playkit-js/playkit-js/dist/playkit';
+
+describe('DashThumbnailController', () => {
+  let thumbnailController, manifestParser;
+  const url = 'my/stream/url';
+
+  it('should parse tracks successfully - one representation', () => {
+    manifestParser = new DashManifestParser(ImageAdaptationSetWithOneRepresentation);
+    manifestParser.parseManifest();
+    thumbnailController = new DashThumbnailController(manifestParser.getImageSet(), url);
+
+    const imageTracks = thumbnailController.getTracks();
+    imageTracks.should.have.lengthOf(1);
+
+    const imageTrack = imageTracks[0];
+    imageTrack.should.be.an.instanceof(ImageTrack);
+    imageTrack.active.should.be.true;
+    imageTrack.index.should.equal(0);
+    imageTrack.id.should.equal('thumbnails_320x180');
+    imageTrack.duration.should.equal(100);
+    imageTrack.cols.should.equal(1);
+    imageTrack.rows.should.equal(10);
+    imageTrack.height.should.equal(180);
+    imageTrack.width.should.equal(3200);
+    imageTrack.url.should.equal('my/stream/thumbnails_320x180/tile_$Number$.jpg');
+    imageTrack.customData.should.deep.equal({
+      bitrate: 12288,
+      startNumber: 1,
+      timescale: 1,
+      presentationTimeOffset: 0
+    });
+  });
+
+  it('should parse tracks successfully - multiple representations', () => {
+    manifestParser = new DashManifestParser(ImageAdaptationSetWithMultipleRepresentations);
+    manifestParser.parseManifest();
+    thumbnailController = new DashThumbnailController(manifestParser.getImageSet(), url);
+
+    const imageTracks = thumbnailController.getTracks();
+    imageTracks.should.have.lengthOf(2);
+
+    const imageTrack1 = imageTracks[0];
+    imageTrack1.should.be.an.instanceof(ImageTrack);
+    imageTrack1.active.should.be.false;
+    imageTrack1.index.should.equal(0);
+    imageTrack1.id.should.equal('thumbnails_102x58');
+    imageTrack1.duration.should.equal(634.566);
+    imageTrack1.cols.should.equal(20);
+    imageTrack1.rows.should.equal(10);
+    imageTrack1.height.should.equal(1152);
+    imageTrack1.width.should.equal(1024);
+    imageTrack1.url.should.equal('my/stream/thumbnails_102x58/tile_$Number$.jpg');
+    imageTrack1.customData.should.deep.equal({
+      bitrate: 12000,
+      presentationTimeOffset: 0,
+      startNumber: 1,
+      timescale: 1
+    });
+
+    const imageTrack2 = imageTracks[1];
+    imageTrack2.should.be.an.instanceof(ImageTrack);
+    imageTrack2.active.should.be.true;
+    imageTrack2.index.should.equal(1);
+    imageTrack2.id.should.equal('thumbnails_256x144');
+    imageTrack2.duration.should.equal(634.566);
+    imageTrack2.cols.should.equal(8);
+    imageTrack2.rows.should.equal(8);
+    imageTrack2.height.should.equal(1152);
+    imageTrack2.width.should.equal(2048);
+    imageTrack2.url.should.equal('my/stream/thumbnails_256x144/tile_$Number$.jpg');
+    imageTrack2.customData.should.deep.equal({
+      bitrate: 24000,
+      presentationTimeOffset: 0,
+      startNumber: 1,
+      timescale: 1
+    });
+  });
+
+  it('should select track successfully for multiple representations', () => {
+    manifestParser = new DashManifestParser(ImageAdaptationSetWithMultipleRepresentations);
+    manifestParser.parseManifest();
+    thumbnailController = new DashThumbnailController(manifestParser.getImageSet(), url);
+
+    let imageTracks;
+    imageTracks = thumbnailController.getTracks();
+    imageTracks.should.have.lengthOf(2);
+    imageTracks[0].active.should.be.false;
+    imageTracks[1].active.should.be.true;
+
+    thumbnailController.selectTrack(imageTracks[0]);
+
+    imageTracks = thumbnailController.getTracks();
+    imageTracks[0].active.should.be.true;
+    imageTracks[1].active.should.be.false;
+
+    thumbnailController.getActiveTrack().should.deep.equal(imageTracks[0]);
+  });
+
+  it('should get thumbnail successfully - one representation', () => {
+    manifestParser = new DashManifestParser(ImageAdaptationSetWithOneRepresentation);
+    manifestParser.parseManifest();
+    thumbnailController = new DashThumbnailController(manifestParser.getImageSet(), url);
+
+    let thumbnailInfo;
+    thumbnailInfo = thumbnailController.getThumbnail(10);
+    thumbnailInfo.height.should.equal(180);
+    thumbnailInfo.url.should.equal('my/stream/thumbnails_320x180/tile_1.jpg');
+    thumbnailInfo.width.should.equal(320);
+    thumbnailInfo.x.should.equal(320);
+    thumbnailInfo.y.should.equal(0);
+
+    thumbnailInfo = thumbnailController.getThumbnail(100);
+    thumbnailInfo.height.should.equal(180);
+    thumbnailInfo.url.should.equal('my/stream/thumbnails_320x180/tile_2.jpg');
+    thumbnailInfo.width.should.equal(320);
+    thumbnailInfo.x.should.equal(0);
+    thumbnailInfo.y.should.equal(0);
+
+    thumbnailInfo = thumbnailController.getThumbnail(2500);
+    thumbnailInfo.height.should.equal(180);
+    thumbnailInfo.url.should.equal('my/stream/thumbnails_320x180/tile_26.jpg');
+    thumbnailInfo.width.should.equal(320);
+    thumbnailInfo.x.should.equal(0);
+    thumbnailInfo.y.should.equal(0);
+  });
+
+  it('should get thumbnail successfully - multiple representations', () => {
+    manifestParser = new DashManifestParser(ImageAdaptationSetWithMultipleRepresentations);
+    manifestParser.parseManifest();
+    thumbnailController = new DashThumbnailController(manifestParser.getImageSet(), url);
+
+    let thumbnailInfo;
+    thumbnailInfo = thumbnailController.getThumbnail(1500);
+    thumbnailInfo.height.should.equal(144);
+    thumbnailInfo.url.should.equal('my/stream/thumbnails_256x144/tile_3.jpg');
+    thumbnailInfo.width.should.equal(256);
+    thumbnailInfo.x.should.equal(1792);
+    thumbnailInfo.y.should.equal(288);
+
+    const inactiveTrack = thumbnailController.getTracks()[0];
+    thumbnailController.selectTrack(inactiveTrack);
+
+    thumbnailInfo = thumbnailController.getThumbnail(1500);
+    thumbnailInfo.height.should.equal(57);
+    thumbnailInfo.url.should.equal('my/stream/thumbnails_102x58/tile_3.jpg');
+    thumbnailInfo.width.should.equal(102);
+    thumbnailInfo.x.should.equal(204.8);
+    thumbnailInfo.y.should.equal(403.2);
+  });
+});

--- a/test/src/parser/dash-manifest-parser.spec.js
+++ b/test/src/parser/dash-manifest-parser.spec.js
@@ -16,7 +16,7 @@ describe('DashManifestParser', () => {
     manifestParser.parseManifest();
     manifestParser.adaptationSets.should.have.lengthOf(1);
 
-    const imageSet = manifestParser.getAdaptationSet(AdaptationSet.ContentType.IMAGE);
+    const imageSet = manifestParser.getImageSet();
     imageSet.should.be.an.instanceof(AdaptationSet);
     (imageSet.essentialProperty === undefined).should.be.true;
     imageSet.id.should.equal('3');
@@ -50,7 +50,7 @@ describe('DashManifestParser', () => {
     manifestParser.parseManifest();
     manifestParser.adaptationSets.should.have.lengthOf(1);
 
-    const imageSet = manifestParser.getAdaptationSet(AdaptationSet.ContentType.IMAGE);
+    const imageSet = manifestParser.getImageSet();
     imageSet.should.be.an.instanceof(AdaptationSet);
     (imageSet.essentialProperty === undefined).should.be.true;
     imageSet.id.should.equal('3');
@@ -96,7 +96,7 @@ describe('DashManifestParser', () => {
     manifestParser.parseManifest();
     manifestParser.adaptationSets.should.have.lengthOf(1);
 
-    const imageSet = manifestParser.getAdaptationSet(AdaptationSet.ContentType.IMAGE);
+    const imageSet = manifestParser.getImageSet();
     imageSet.should.be.an.instanceof(AdaptationSet);
     imageSet.id.should.equal('thumbnails');
     imageSet.contentType.should.equal(AdaptationSet.ContentType.IMAGE);

--- a/test/src/parser/manifests.js
+++ b/test/src/parser/manifests.js
@@ -1,6 +1,4 @@
-import {ParserUtils} from '../../../src/parser/parser-utils';
-
-const ImageAdaptationSetWithOneRepresentation = ParserUtils.StrToBuffer(`
+const ImageAdaptationSetWithOneRepresentation = `
   <MPD mediaPresentationDuration="PT634.566S" minBufferTime="PT2.00S" profiles="urn:hbbtv:dash:profile:isoff-live:2012,urn:mpeg:dash:profile:isoff-live:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd">
  <BaseURL>./</BaseURL>
  <Period>
@@ -33,9 +31,9 @@ const ImageAdaptationSetWithOneRepresentation = ParserUtils.StrToBuffer(`
   </AdaptationSet>
  </Period>
 </MPD>
-  `);
+  `;
 
-const ImageAdaptationSetWithMultipleRepresentations = ParserUtils.StrToBuffer(`
+const ImageAdaptationSetWithMultipleRepresentations = `
  <MPD mediaPresentationDuration="PT634.566S" minBufferTime="PT2.00S" profiles="urn:hbbtv:dash:profile:isoff-live:2012,urn:mpeg:dash:profile:isoff-live:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd">
     <BaseURL>./</BaseURL>
     <Period>
@@ -71,9 +69,9 @@ const ImageAdaptationSetWithMultipleRepresentations = ParserUtils.StrToBuffer(`
         </AdaptationSet>
     </Period>
 </MPD>
-  `);
+  `;
 
-const ImageAdaptationWithEssentialUnderAdaptation = ParserUtils.StrToBuffer(`
+const ImageAdaptationWithEssentialUnderAdaptation = `
 <MPD mediaPresentationDuration="PT634.566S" minBufferTime="PT2.00S" profiles="urn:hbbtv:dash:profile:isoff-live:2012,urn:mpeg:dash:profile:isoff-live:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd">
     <BaseURL>./</BaseURL>
     <Period>
@@ -106,6 +104,6 @@ const ImageAdaptationWithEssentialUnderAdaptation = ParserUtils.StrToBuffer(`
         </AdaptationSet>
     </Period>
 </MPD>
-`);
+`;
 
 export {ImageAdaptationSetWithOneRepresentation, ImageAdaptationSetWithMultipleRepresentations, ImageAdaptationWithEssentialUnderAdaptation};

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,10 +853,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@playkit-js/playkit-js@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.65.0.tgz#b7e7f7edd7c54e7befa8f67b1d42fb698966ba59"
-  integrity sha512-MVKeSt2OOgujjaBSbqXEom5mxJdLvJGSC6UczSxEzAqCHjy5oCLaoCQYygChaXB9HpP3S+Y3utCOF/7mZ4LbgA==
+"@playkit-js/playkit-js@0.68.0-canary.3b1d78e":
+  version "0.68.0-canary.3b1d78e"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.68.0-canary.3b1d78e.tgz#1a28e435742e3f2aeca40a724b69cec0b9d015cb"
+  integrity sha512-u5rkeodIhhNWw145BTyppydEiMAl3rVDF4GUMV7z2eGKwwUNqM11bgVfB6gkam5RwvMUyoA5Hsy71mWOt1wuIA==
   dependencies:
     js-logger "^1.6.0"
     ua-parser-js "^0.7.21"


### PR DESCRIPTION
### Description of the Changes

* Add `DashThumbnailController` which controls and manage the image tracks.
* Add `getThumbnail(time: number): ?ThumbnailInfo` API implementation.
* Add parsing image tracks mechanism.
* Add `selectImageTrack` API implementation
* Add logic which optimise the manifest parsing on live manifests.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
