### PR TITLE
fix(FEC-11082): remove handling of DOM play error on SmartTV on when stall happen on the beginning

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -361,27 +361,10 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     if (this._config.shakaConfig.useShakaTextTrackDisplay) {
       this._shaka.setVideoContainer(Utils.Dom.getElementBySelector('.playkit-subtitles'));
     }
-    this._maybeFixStallForSmartTV();
     this._maybeSetFilters();
     this._maybeSetDrmConfig();
     this._shaka.configure(this._config.shakaConfig);
     this._addBindings();
-  }
-
-  /**
-   * fix stall play promise rejected by seeking on the beginning instead of play pause
-   * @returns {void}
-   * @private
-   */
-  _maybeFixStallForSmartTV(): void {
-    const defaultStallSkip = 0.1;
-    const currentStallSkip = this._shaka.getConfiguration().streaming.stallSkip;
-    Utils.Object.mergeDeep(this._config.shakaConfig, {streaming: {stallSkip: defaultStallSkip}});
-    this._eventManager.listenOnce(this._videoElement, EventType.PLAYING, () => {
-      if (currentStallSkip !== this._shaka.getConfiguration().streaming.stallSkip) {
-        this._shaka.configure({streaming: {stallSkip: currentStallSkip}});
-      }
-    });
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Issue: stall detector doesn't get the change of stallSkip after it loaded and stallSkip 0.1 cause freezes on old SmartTV.
Solution: Handle it on playkit https://github.com/kaltura/playkit-js/pull/552
### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
