### PR TITLE
fix(FEC-11126): upgrade shaka to 3.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "mocha": "^8.0.1",
     "mocha-cli": "^1.0.1",
     "prettier": "^2.0.5",
-    "shaka-player": "3.0.8",
+    "shaka-player": "3.0.10",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "standard-version": "^6.0.1",

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -859,7 +859,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
         let kind = textTracks[i].kind ? textTracks[i].kind + 's' : '';
-        kind = kind === '' && this._config.useShakaTextTrackDisplay ? 'captions' : kind;
+        kind = kind === '' && this._config.useShakaTextTrackDisplay ? 'smtpe-tt-captions' : kind;
         let settings = {
           kind: kind,
           active: false,
@@ -938,7 +938,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   selectTextTrack(textTrack: TextTrack): void {
-    if (this._shaka && textTrack instanceof TextTrack && !textTrack.active && (textTrack.kind === 'subtitles' || textTrack.kind === 'captions')) {
+    if (
+      this._shaka &&
+      textTrack instanceof TextTrack &&
+      !textTrack.active &&
+      (textTrack.kind === 'subtitles' || textTrack.kind === 'captions' || textTrack.kind === 'smtpe-tt-captions')
+    ) {
       this._shaka.setTextTrackVisibility(this._config.textTrackVisibile);
       this._shaka.selectTextLanguage(textTrack.language);
       this._onTrackChanged(textTrack);

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -187,7 +187,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _thumbnailController: ?DashThumbnailController;
-
   /**
    * Factory method to create media source adapter.
    * @function createAdapter
@@ -201,6 +200,9 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     let adapterConfig: Object = Utils.Object.copyDeep(DefaultConfig);
     if (Utils.Object.hasPropertyPath(config, 'text.useNativeTextTrack')) {
       adapterConfig.textTrackVisibile = Utils.Object.getPropertyPath(config, 'text.useNativeTextTrack');
+    }
+    if (Utils.Object.hasPropertyPath(config, 'text.useShakaTextTrackDisplay')) {
+      adapterConfig.useShakaTextTrackDisplay = Utils.Object.getPropertyPath(config, 'text.useShakaTextTrackDisplay');
     }
     if (Utils.Object.hasPropertyPath(config, 'sources.options')) {
       const options = config.sources.options;
@@ -358,7 +360,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     shaka.polyfill.installAll();
     this._shaka = new shaka.Player();
     //render text tracks to our own container
-    if (this._config.shakaConfig.useShakaTextTrackDisplay) {
+    if (this._config.useShakaTextTrackDisplay) {
       this._shaka.setVideoContainer(Utils.Dom.getElementBySelector('.playkit-subtitles'));
     }
     this._maybeSetFilters();
@@ -934,7 +936,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   selectTextTrack(textTrack: TextTrack): void {
-    if (this._shaka && textTrack instanceof TextTrack && !textTrack.active && (textTrack.kind === 'subtitles' || textTrack.kind === 'captions')) {
+    if (
+      this._shaka &&
+      textTrack instanceof TextTrack &&
+      !textTrack.active &&
+      (textTrack.kind === 'subtitles' || textTrack.kind === 'captions' || this._config.useShakaTextTrackDisplay)
+    ) {
       this._shaka.setTextTrackVisibility(this._config.textTrackVisibile);
       this._shaka.selectTextLanguage(textTrack.language);
       this._onTrackChanged(textTrack);

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -858,8 +858,10 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     let parsedTracks = [];
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
+        let kind = textTracks[i].kind ? textTracks[i].kind + 's' : '';
+        kind = kind === '' && this._config.useShakaTextTrackDisplay ? 'captions' : kind;
         let settings = {
-          kind: textTracks[i].kind ? textTracks[i].kind + 's' : '',
+          kind: kind,
           active: false,
           label: textTracks[i].label,
           language: textTracks[i].language,
@@ -936,12 +938,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   selectTextTrack(textTrack: TextTrack): void {
-    if (
-      this._shaka &&
-      textTrack instanceof TextTrack &&
-      !textTrack.active &&
-      (textTrack.kind === 'subtitles' || textTrack.kind === 'captions' || this._config.useShakaTextTrackDisplay)
-    ) {
+    if (this._shaka && textTrack instanceof TextTrack && !textTrack.active && (textTrack.kind === 'subtitles' || textTrack.kind === 'captions')) {
       this._shaka.setTextTrackVisibility(this._config.textTrackVisibile);
       this._shaka.selectTextLanguage(textTrack.language);
       this._onTrackChanged(textTrack);

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -859,7 +859,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
         let kind = textTracks[i].kind ? textTracks[i].kind + 's' : '';
-        kind = kind === '' && this._config.useShakaTextTrackDisplay ? 'smtpe-tt-captions' : kind;
+        kind = kind === '' && this._config.useShakaTextTrackDisplay ? 'captions' : kind;
         let settings = {
           kind: kind,
           active: false,
@@ -938,12 +938,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   selectTextTrack(textTrack: TextTrack): void {
-    if (
-      this._shaka &&
-      textTrack instanceof TextTrack &&
-      !textTrack.active &&
-      (textTrack.kind === 'subtitles' || textTrack.kind === 'captions' || textTrack.kind === 'smtpe-tt-captions')
-    ) {
+    if (this._shaka && textTrack instanceof TextTrack && !textTrack.active && (textTrack.kind === 'subtitles' || textTrack.kind === 'captions')) {
       this._shaka.setTextTrackVisibility(this._config.textTrackVisibile);
       this._shaka.selectTextLanguage(textTrack.language);
       this._onTrackChanged(textTrack);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7340,10 +7340,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaka-player@3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-3.0.8.tgz#32e4c321b80012bca9db9a20b7ec63eefd7df512"
-  integrity sha512-4nROuGUhmtOTERWVO31pp/hvtdCy/kW/Ys6KQwqRhFeCsZsU1/8768dJUyXKqNnbYybKIvuv6LqO8egkXy6TjA==
+shaka-player@3.0.10:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-3.0.10.tgz#f5cca848df54694f1aa77097f990881da11dbf68"
+  integrity sha512-kr1OFbihAmsmtsb/QhyDfxkt05wPAdreiW8vF86RN95zxpp+J/thEcTjRrH0E9dkBwPwS4HVv+mm096uqtEMvA==
   dependencies:
     eme-encryption-scheme-polyfill "^2.0.1"
 


### PR DESCRIPTION
### Description of the Changes

SMPTE-TT Subtitles fix
- updated shaka to 3.0.10
- moved useShakaTextTrackDisplay from playback.options.playback.options.html5.dash to text
- added useShakaTextTrackDisplay in _getParsedTextTracks when creating TextTrack and kind is an empty string

depends on https://github.com/kaltura/kaltura-player-js/pull/432
solves FEC-11126

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
