### PR TITLE
fix(FEC-11126): select the lowest value if we're not adaptive mode

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -564,16 +564,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       this._clearVideoUpdateTimer();
       if (Utils.Object.hasPropertyPath(this._config, 'abr.restrictions')) {
         this._updateRestriction(this._config.abr.restrictions);
-        if (!this.isAdaptiveBitrateEnabled()) {
-          const videoTracks = this._getParsedVideoTracks();
-          const availableTracks = filterTracksByRestriction(videoTracks, this._config.abr.restrictions);
-          if (availableTracks.length) {
-            const activeTrackInRange = availableTracks.find(track => track.active);
-            if (!activeTrackInRange) {
-              this.selectVideoTrack(availableTracks[0]);
-            }
-          }
-        }
       }
     }
   }
@@ -1113,6 +1103,16 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   applyABRRestriction(restrictions: PKABRRestrictionObject): void {
     Utils.Object.createPropertyPath(this._config, 'abr.restrictions', restrictions);
     this._maybeApplyAbrRestrictions();
+    if (!this.isAdaptiveBitrateEnabled()) {
+      const videoTracks = this._getParsedVideoTracks();
+      const availableTracks = filterTracksByRestriction(videoTracks, this._config.abr.restrictions);
+      if (availableTracks.length) {
+        const activeTrackInRange = availableTracks.find(track => track.active);
+        if (!activeTrackInRange) {
+          this.selectVideoTrack(availableTracks[0]);
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Issue: doesn't adaptive should select the first one if it's not in the range for capToPlayerSize and ABR restrictions.
Solution: always select the first one if it's not adaptive.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
