### PR TITLE
fix(FEC-11268): incorrect video bandwidth parsed

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -913,7 +913,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       for (let i = 0; i < videoTracks.length; i++) {
         let settings = {
           id: videoTracks[i].id,
-          bandwidth: videoTracks[i].bandwidth,
+          bandwidth: videoTracks[i].videoBandwidth || videoTracks[i].bandwidth,
           width: videoTracks[i].width,
           height: videoTracks[i].height,
           active: videoTracks[i].active,

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -470,7 +470,7 @@ describe('DashAdapter: _getParsedTracks', () => {
             if (track instanceof VideoTrack) {
               track.id.should.equal(videoTracks[track.index].id);
               track.active.should.equal(videoTracks[track.index].active);
-              track.bandwidth.should.equal(videoTracks[track.index].bandwidth);
+              track.bandwidth.should.equal(videoTracks[track.index].videoBandwidth);
             }
             if (track instanceof AudioTrack) {
               track.id.should.equal(audioTracks[track.index].id);


### PR DESCRIPTION
### Description of the Changes

Issue: ABR auto-selection doesn't select the correct bandwidth.
Solution: Shaka parsing the variants with bandwidth for a variant which could be the bandwidth video itself or video+audio.
Select the videoBandwidth if it exists.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
