### PR TITLE
fix(FEC-11270): cap to player size doesn't apply

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -564,16 +564,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       this._clearVideoUpdateTimer();
       if (Utils.Object.hasPropertyPath(this._config, 'abr.restrictions')) {
         this._updateRestriction(this._config.abr.restrictions);
-        if (!this.isAdaptiveBitrateEnabled()) {
-          const videoTracks = this._getParsedVideoTracks();
-          const availableTracks = filterTracksByRestriction(videoTracks, this._config.abr.restrictions);
-          if (availableTracks.length) {
-            const activeTrackInRange = availableTracks.find(track => track.active);
-            if (!activeTrackInRange) {
-              this.selectVideoTrack(availableTracks[0]);
-            }
-          }
-        }
       }
     }
   }
@@ -1113,6 +1103,16 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   applyABRRestriction(restrictions: PKABRRestrictionObject): void {
     Utils.Object.createPropertyPath(this._config, 'abr.restrictions', restrictions);
     this._maybeApplyAbrRestrictions();
+    if (!this.isAdaptiveBitrateEnabled()) {
+      const videoTracks = this._getParsedVideoTracks();
+      const availableTracks = filterTracksByRestriction(videoTracks, this._config.abr.restrictions);
+      if (availableTracks.length) {
+        const activeTrackInRange = availableTracks.find(track => track.active);
+        if (!activeTrackInRange) {
+          this.selectVideoTrack(availableTracks[0]);
+        }
+      }
+    }
   }
 
   /**

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -769,6 +769,10 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
             })
             .then(() => {
               const data = {tracks: this._getParsedTracks()};
+              //handle cap player to level size
+              if (this._config.capLevelToPlayerSize) {
+                this._maybeApplyAbrRestrictions();
+              }
               DashAdapter._logger.debug('The source has been loaded successfully');
               resolve(data);
             })

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -541,11 +541,11 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   }
 
   /**
-   * apply ABR restrictions
+   * apply Capping to player size restrictions
    * @private
    * @returns {void}
    */
-  _maybeApplyAbrRestrictions(): void {
+  _maybeCapLevelToPlayerSize(): void {
     if (this._config.capLevelToPlayerSize) {
       const getRestrictions = () => {
         return {
@@ -560,7 +560,16 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       this._clearVideoUpdateTimer();
       this._videoSizeUpdateTimer = setInterval(() => this._updateRestriction(getRestrictions()), ABR_RESTRICTION_UPDATE_INTERVAL);
       this._updateRestriction(getRestrictions());
-    } else {
+    }
+  }
+
+  /**
+   * apply ABR restrictions
+   * @private
+   * @returns {void}
+   */
+  _maybeApplyAbrRestrictions(): void {
+    if (!this._config.capLevelToPlayerSize) {
       this._clearVideoUpdateTimer();
       if (Utils.Object.hasPropertyPath(this._config, 'abr.restrictions')) {
         this._updateRestriction(this._config.abr.restrictions);
@@ -769,10 +778,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
             })
             .then(() => {
               const data = {tracks: this._getParsedTracks()};
-              //handle cap player to level size
-              if (this._config.capLevelToPlayerSize) {
-                this._maybeApplyAbrRestrictions();
-              }
+              this._maybeCapLevelToPlayerSize();
               DashAdapter._logger.debug('The source has been loaded successfully');
               resolve(data);
             })


### PR DESCRIPTION
### Description of the Changes

Issue: applyRestriction doesn't trigger from playkit, no restriction has changed.
Solution: should apply the logic for capLevelToPlayerSize once tracks are available., it shouldn't change from playkit at all.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
