### PR TITLE
fix(FEC-11419): explore why Live Start over starts with few seconds delay

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1286,7 +1286,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   getStartTimeOfDvrWindow(): number {
     if (this.isLive() && this._shaka) {
-      return this._shaka.seekRange().start;
+      return this._shaka.seekRange().start + this._shaka.getConfiguration().streaming.safeSeekOffset;
     }
     return 0;
   }

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -1353,7 +1353,9 @@ describe('DashAdapter: getStartTimeOfDvrWindow', () => {
       .load()
       .then(() => {
         try {
-          dashInstance.getStartTimeOfDvrWindow().should.equal(dashInstance._shaka.seekRange().start);
+          Math.floor(dashInstance.getStartTimeOfDvrWindow()).should.equal(
+            Math.floor(dashInstance._shaka.seekRange().start + dashInstance._shaka.getConfiguration().streaming.safeSeekOffset)
+          );
           done();
         } catch (e) {
           done(e);


### PR DESCRIPTION
### Description of the Changes

add `safeSeekOffset` to the dvr window calculation 

Solves FEC-11419

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
