### PR TITLE
fix(FEC-11473): start of dvr window is going back and forth while start over

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -34,7 +34,7 @@ module.exports = function (config) {
     client: {
       mocha: {
         reporter: 'html',
-        timeout: 10000
+        timeout: 20000
       }
     }
   };

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1299,14 +1299,15 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   getStartTimeOfDvrWindow(): number {
     if (this.isLive() && this._shaka) {
+      const newSeekRangeStart = this._shaka.seekRange().start;
       if (!this._isStartOver) {
-        if (this._seekRangeStart > this._shaka.seekRange().start) {
+        if (this._seekRangeStart > newSeekRangeStart) {
           // seekRange().start seeked back means this is start over
           this._isStartOver = true;
         }
-        this._seekRangeStart = this._shaka.seekRange().start;
+        this._seekRangeStart = newSeekRangeStart;
       }
-      return (this._isStartOver ? this._seekRangeStart : this._shaka.seekRange().start) + this._shaka.getConfiguration().streaming.safeSeekOffset;
+      return (this._isStartOver ? this._seekRangeStart : newSeekRangeStart) + this._shaka.getConfiguration().streaming.safeSeekOffset;
     }
     return 0;
   }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -753,6 +753,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._seekRangeStart = this._shaka.seekRange().start;
     this._startOverTimeout = setTimeout(() => {
       if (this._shaka.seekRange().start - this._seekRangeStart >= segmentDuration) {
+        // in start over the seekRange().start should be permanent
         this._isStartOver = false;
       }
     }, segmentDuration * 1000);

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1301,6 +1301,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     if (this.isLive() && this._shaka) {
       if (!this._isStartOver) {
         if (this._seekRangeStart > this._shaka.seekRange().start) {
+          // seekRange().start seeked back means this is start over
           this._isStartOver = true;
         }
         this._seekRangeStart = this._shaka.seekRange().start;

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -739,6 +739,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         case shaka.net.NetworkingEngine.RequestType.MANIFEST:
           this._parseManifest(response.data);
           this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
+          this._seekRangeStart = null;
           break;
       }
     });
@@ -1297,7 +1298,8 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   getStartTimeOfDvrWindow(): number {
     if (this.isLive() && this._shaka) {
-      return this._shaka.seekRange().start + this._shaka.getConfiguration().streaming.safeSeekOffset;
+      this._seekRangeStart = this._seekRangeStart || this._shaka.seekRange().start;
+      return this._seekRangeStart + this._shaka.getConfiguration().streaming.safeSeekOffset;
     }
     return 0;
   }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -216,6 +216,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _thumbnailController: ?DashThumbnailController;
+  _seekRangeStart: ?number;
 
   /**
    * Factory method to create media source adapter.

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -218,7 +218,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   _thumbnailController: ?DashThumbnailController;
   _isStartOver: boolean = true;
   _seekRangeStart: number = 0;
-  _startOverTimeout: number;
+  _startOverTimeout: TimeoutID;
 
   /**
    * Factory method to create media source adapter.

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -756,7 +756,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         // in start over the seekRange().start should be permanent
         this._isStartOver = false;
       }
-    }, segmentDuration * 1000);
+    }, (segmentDuration + 1) * 1000);
   }
 
   /**

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -216,7 +216,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _thumbnailController: ?DashThumbnailController;
-  _seekRangeStart: ?number;
+  _seekRangeStart: number;
 
   /**
    * Factory method to create media source adapter.
@@ -740,7 +740,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         case shaka.net.NetworkingEngine.RequestType.MANIFEST:
           this._parseManifest(response.data);
           this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
-          this._seekRangeStart = null;
+          this._seekRangeStart = this._shaka.seekRange().start;
           break;
       }
     });
@@ -1299,7 +1299,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   getStartTimeOfDvrWindow(): number {
     if (this.isLive() && this._shaka) {
-      this._seekRangeStart = this._seekRangeStart || this._shaka.seekRange().start;
       return this._seekRangeStart + this._shaka.getConfiguration().streaming.safeSeekOffset;
     }
     return 0;

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -1342,9 +1342,8 @@ describe('DashAdapter: getStartTimeOfDvrWindow', () => {
 
   it('should return the start time of Dvr window for live', done => {
     dashInstance = DashAdapter.createAdapter(video, liveSource, config);
-    dashInstance
-      .load()
-      .then(() => {
+    video.addEventListener(EventType.LOADED_DATA, () => {
+      setTimeout(() => {
         try {
           Math.floor(dashInstance.getStartTimeOfDvrWindow()).should.equal(
             Math.floor(dashInstance._shaka.seekRange().start + dashInstance._shaka.getConfiguration().streaming.safeSeekOffset)
@@ -1353,10 +1352,9 @@ describe('DashAdapter: getStartTimeOfDvrWindow', () => {
         } catch (e) {
           done(e);
         }
-      })
-      .catch(e => {
-        done(e);
-      });
+      }, (dashInstance.getSegmentDuration() + 1) * 1000);
+    });
+    dashInstance.load();
   });
 });
 

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -1352,7 +1352,7 @@ describe('DashAdapter: getStartTimeOfDvrWindow', () => {
         } catch (e) {
           done(e);
         }
-      }, (dashInstance.getSegmentDuration() + 1) * 1000);
+      }, (dashInstance.getSegmentDuration() + 2) * 1000);
     });
     dashInstance.load();
   });


### PR DESCRIPTION
### Description of the Changes

shaka is increasing the `seekRange.start` between manifest loadings.
so ignore this update if it's start over.

Solves FEC-11473

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
