### PR TITLE
fix(FEC-11492): dash adapter is not destroyed when network is offline

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1214,6 +1214,9 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       }
       this._trigger(EventType.ERROR, new Error(error.severity, error.category, error.code, error.data));
       DashAdapter._logger.error(error);
+      if (error.severity === Error.Severity.CRITICAL) {
+        this.destroy();
+      }
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

**issue:**
once dash is triggering critical error event, we are not destroying the engine.

**solution:**
destroying engine when critical event is being fired.

Solves FEC-11492

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
