### PR TITLE
fix: do not remove shaka event bindings on reset but in destroy

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -826,6 +826,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       super.destroy().then(() => {
         DashAdapter._logger.debug('destroy');
         this._loadPromise = null;
+        this._adapterEventsBindings = {};
         this._reset()
           .then(resetResult => {
             this._isDestroyInProgress = false;
@@ -872,7 +873,6 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       this._eventManager.removeAll();
     }
     if (this._shaka) {
-      this._adapterEventsBindings = {};
       return this._shaka.destroy();
     }
     return Promise.resolve();


### PR DESCRIPTION
### Description of the Changes

currently, we remove shaka event binding on reset so we dont get shaka events after detach/attach 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
