### PR TITLE
fix(FEC-12089): Tizen playback breaks after ad finishes

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -786,8 +786,9 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @function load
    * @override
    */
-  load(startTime: ?number): Promise<Object> {
+  async load(startTime: ?number): Promise<Object> {
     if (!this._loadPromise) {
+      await this._removeMediaKeys();
       this._shaka.attach(this._videoElement);
       this._loadPromise = new Promise((resolve, reject) => {
         if (this._sourceObj && this._sourceObj.url) {
@@ -876,6 +877,30 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       return this._shaka.destroy();
     }
     return Promise.resolve();
+  }
+
+  /**
+   * Remove mediaKeys from the video element.
+   * mediaKeys are set if an encrypted media was previously played, and must be removed before a new encrypted media can be played.
+   * If mediaKeys are not null it means that shaka reset wasn't called or that it failed to remove them.
+   * @returns {Promise<void>} Promise that resolves when the operation finishes.
+   */
+  async _removeMediaKeys(): Promise<void> {
+    if (this._videoElement && this._videoElement.mediaKeys) {
+      try {
+        DashAdapter._logger.debug('Removing mediaKeys from the video element');
+        await this._videoElement.setMediaKeys(null);
+        DashAdapter._logger.debug('mediaKeys removed');
+      } catch (e) {
+        // non encrypted playback should still work even so we don't reject
+        this._logger.warn('mediaKeys not cleared');
+      } finally {
+        // eslint-disable-next-line no-unsafe-finally
+        return Promise.resolve();
+      }
+    } else {
+      return Promise.resolve();
+    }
   }
 
   /**

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -270,6 +270,18 @@ describe('DashAdapter: load', () => {
       done();
     });
   });
+
+  it('should try to remove media keys on load', done => {
+    config = {playback: {options: {html5: {dash: {drm: {advanced: {'com.widevine.alpha': {videoRobustness: 'HW_SECURE_ALL'}}}}}}}};
+    DashAdapter._availableDrmProtocol.push(Widevine);
+    dashInstance = DashAdapter.createAdapter(video, {drmData: wwDrmData}, config);
+    global.sinon.stub(dashInstance._shaka, 'attach');
+
+    const removeMediaKeys = global.sinon.spy(dashInstance, '_removeMediaKeys');
+    dashInstance.load();
+    removeMediaKeys.should.have.callCount(1);
+    done();
+  });
 });
 
 describe('DashAdapter: targetBuffer', () => {

--- a/test/src/dash-adapter.spec.js
+++ b/test/src/dash-adapter.spec.js
@@ -272,14 +272,11 @@ describe('DashAdapter: load', () => {
   });
 
   it('should try to remove media keys on load', done => {
-    config = {playback: {options: {html5: {dash: {drm: {advanced: {'com.widevine.alpha': {videoRobustness: 'HW_SECURE_ALL'}}}}}}}};
-    DashAdapter._availableDrmProtocol.push(Widevine);
-    dashInstance = DashAdapter.createAdapter(video, {drmData: wwDrmData}, config);
-    global.sinon.stub(dashInstance._shaka, 'attach');
-
+    dashInstance = DashAdapter.createAdapter(video, vodSource, config);
     const removeMediaKeys = global.sinon.spy(dashInstance, '_removeMediaKeys');
     dashInstance.load();
     removeMediaKeys.should.have.callCount(1);
+    removeMediaKeys.restore();
     done();
   });
 });


### PR DESCRIPTION
### Description of the Changes

Make sure mediaKeys are removed before calling load, otherwise playing encrypted media can fail.
This can happen if reset was not called before load or if shaka failed to remove the mediaKeys on reset, which is something that can happen specifically when using the same video element for ads like with ima on smart tv.

Resolves FEC-12089

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
