### PR TITLE
fix(FEC-12479): [Dash] - Subtitles are too small and not centered

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,29 +1,37 @@
-.shaka-text-container {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  width: 100%;
-  min-width: 48px;
-  transition: bottom cubic-bezier(0.4, 0, 0.6, 1) 0.1s;
-  transition-delay: 0.5s;
-  font-size: 20px;
-  line-height: 1.4;
+.shaka-text-container{
+  position:absolute;
+  left:0;
+  right:0;
+  top:0;
+  bottom:15%;
+  pointer-events:none;
+  width:100%;
+  min-width:48px;
+  transition:bottom cubic-bezier(.4, 0, .6, 1) .1s;
+  transition-delay:0s;
+  font-size:20px;
+  line-height:1.4;
+  color:#fff;
+  font-family: Roboto-Regular, Roboto, sans-serif, TengwarTelcontar;
+}
+.shaka-text-container span.shaka-text-wrapper{
+  display:inline;
+  background:0 0;
+  text-align: center;
 }
 
-.shaka-text-container * {
-  font-size: 20px;
-  line-height: 1.4;
+:fullscreen .shaka-text-container{
+  font-size:4.4vmin
 }
 
-.shaka-text-container span {
-  background-color: rgba(0, 0, 0, 0.8);
-  color: #fff;
-  display: inline-block;
+:-webkit-full-screen .shaka-text-container{
+  font-size:4.4vmin
 }
 
-.shaka-text-container .shaka-nested-cue:not(:last-of-type):after {
-  content: ' ';
-  white-space: pre;
+:-moz-full-screen .shaka-text-container{
+  font-size:4.4vmin
+}
+
+:-ms-fullscreen .shaka-text-container{
+  font-size:4.4vmin
 }

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -3,7 +3,7 @@
   left:0;
   right:0;
   top:0;
-  bottom:15%;
+  bottom:0;
   pointer-events:none;
   width:100%;
   min-width:48px;

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -398,9 +398,10 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     //Need to call this again cause we are uninstalling the VTTCue polyfill to avoid collisions with other libs
     shaka.polyfill.installAll();
     this._shaka = new shaka.Player();
-    //render text tracks to our own container
+    // This will force the player to use shaka UITextDisplayer plugin to render text tracks.
     if (this._config.useShakaTextTrackDisplay) {
-      this._shaka.setVideoContainer(Utils.Dom.getElementBySelector('.playkit-subtitles'));
+      const playerContainer = document.getElementsByClassName('playkit-container')[0];
+      this._shaka.setVideoContainer(playerContainer);
     }
     this._maybeSetFilters();
     this._maybeSetDrmConfig();

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -400,8 +400,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._shaka = new shaka.Player();
     // This will force the player to use shaka UITextDisplayer plugin to render text tracks.
     if (this._config.useShakaTextTrackDisplay) {
-      const playerContainer = document.getElementsByClassName('playkit-container')[0];
-      this._shaka.setVideoContainer(playerContainer);
+      this._shaka.setVideoContainer(Utils.Dom.getElementBySelector('.playkit-subtitles'));
     }
     this._maybeSetFilters();
     this._maybeSetDrmConfig();


### PR DESCRIPTION
### Description of the Changes

issue: the player uses the shaka UITextDisplayer plugin to render text tracks with our container but does not load all relevant CSS class

fix: update the CSS file and replace the container

solves: FEC-12479

related pr: https://github.com/kaltura/playkit-js/pull/660

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
