### PR TITLE
fix(FEC-12539): Shaka text displayer font size too small on TVs

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -35,9 +35,3 @@
 :-ms-fullscreen .shaka-text-container {
   font-size: 4.4vmin;
 }
-
-@media screen and (min-width: 1240px) {
-  .shaka-text-container {
-    font-size: 4.4vmin;
-  }
-}

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,37 +1,43 @@
-.shaka-text-container{
-  position:absolute;
-  left:0;
-  right:0;
-  top:0;
-  bottom:0;
-  pointer-events:none;
-  width:100%;
-  min-width:48px;
-  transition:bottom cubic-bezier(.4, 0, .6, 1) .1s;
-  transition-delay:0s;
-  font-size:20px;
-  line-height:1.4;
-  color:#fff;
+.shaka-text-container {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  pointer-events: none;
+  width: 100%;
+  min-width: 48px;
+  transition: bottom cubic-bezier(0.4, 0, 0.6, 1) 0.1s;
+  transition-delay: 0s;
+  font-size: 20px;
+  line-height: 1.4;
+  color: #fff;
   font-family: Roboto-Regular, Roboto, sans-serif, TengwarTelcontar;
 }
-.shaka-text-container span.shaka-text-wrapper{
-  display:inline;
-  background:0 0;
+.shaka-text-container span.shaka-text-wrapper {
+  display: inline;
+  background: 0 0;
   text-align: center;
 }
 
-:fullscreen .shaka-text-container{
-  font-size:4.4vmin
+:fullscreen .shaka-text-container {
+  font-size: 4.4vmin;
 }
 
-:-webkit-full-screen .shaka-text-container{
-  font-size:4.4vmin
+:-webkit-full-screen .shaka-text-container {
+  font-size: 4.4vmin;
 }
 
-:-moz-full-screen .shaka-text-container{
-  font-size:4.4vmin
+:-moz-full-screen .shaka-text-container {
+  font-size: 4.4vmin;
 }
 
-:-ms-fullscreen .shaka-text-container{
-  font-size:4.4vmin
+:-ms-fullscreen .shaka-text-container {
+  font-size: 4.4vmin;
+}
+
+@media screen and (min-width: 1240px) {
+  .shaka-text-container {
+    font-size: 4.4vmin;
+  }
 }

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1,6 +1,7 @@
 // @flow
 import shaka from 'shaka-player';
 import {
+  Env,
   AudioTrack,
   BaseMediaSourceAdapter,
   Error,
@@ -398,15 +399,22 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     //Need to call this again cause we are uninstalling the VTTCue polyfill to avoid collisions with other libs
     shaka.polyfill.installAll();
     this._shaka = new shaka.Player();
-    // This will force the player to use shaka UITextDisplayer plugin to render text tracks.
-    if (this._config.useShakaTextTrackDisplay) {
-      this._shaka.setVideoContainer(Utils.Dom.getElementBySelector('.playkit-subtitles'));
-    }
+    this._setTextDisplayer();
     this._maybeSetFilters();
     this._maybeSetDrmConfig();
     this._maybeBreakStalls();
     this._shaka.configure(this._config.shakaConfig);
     this._addBindings();
+  }
+
+  _setTextDisplayer() {
+    // This will force the player to use shaka UITextDisplayer plugin to render text tracks.
+    if (this._config.useShakaTextTrackDisplay) {
+      this._shaka.setVideoContainer(Utils.Dom.getElementBySelector('.playkit-subtitles'));
+      if (Env.isSmartTV) {
+        document.querySelector('.shaka-text-container').style.fontsize = '4.4vmin';
+      }
+    }
   }
 
   _clearStallInterval(): void {


### PR DESCRIPTION
### Description of the Changes

solves: FEC-12539 - Regression 

**issue:** the previous fix is incorrect since the media query refers to the screen size and not the player size

**fix:** The :fullscreen [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) [pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) is not applied in samrtTvs, so instead i relying on the Env.IsSmartTv env variable 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
