### PR TITLE
fix(FEC-12539): Shaka text displayer font size too small on TVs - revert

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -35,3 +35,9 @@
 :-ms-fullscreen .shaka-text-container {
   font-size: 4.4vmin;
 }
+
+@media screen and (min-width: 1240px) {
+  .shaka-text-container {
+    font-size: 4.4vmin;
+  }
+}

--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1,7 +1,6 @@
 // @flow
 import shaka from 'shaka-player';
 import {
-  Env,
   AudioTrack,
   BaseMediaSourceAdapter,
   Error,
@@ -399,22 +398,15 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     //Need to call this again cause we are uninstalling the VTTCue polyfill to avoid collisions with other libs
     shaka.polyfill.installAll();
     this._shaka = new shaka.Player();
-    this._setTextDisplayer();
+    // This will force the player to use shaka UITextDisplayer plugin to render text tracks.
+    if (this._config.useShakaTextTrackDisplay) {
+      this._shaka.setVideoContainer(Utils.Dom.getElementBySelector('.playkit-subtitles'));
+    }
     this._maybeSetFilters();
     this._maybeSetDrmConfig();
     this._maybeBreakStalls();
     this._shaka.configure(this._config.shakaConfig);
     this._addBindings();
-  }
-
-  _setTextDisplayer() {
-    // This will force the player to use shaka UITextDisplayer plugin to render text tracks.
-    if (this._config.useShakaTextTrackDisplay) {
-      this._shaka.setVideoContainer(Utils.Dom.getElementBySelector('.playkit-subtitles'));
-      if (Env.isSmartTV) {
-        document.querySelector('.shaka-text-container').style.fontsize = '4.4vmin';
-      }
-    }
   }
 
   _clearStallInterval(): void {


### PR DESCRIPTION
Reverts kaltura/playkit-js-dash#208