### PR TITLE
fix(FEC-12615): add configuration to toggle emsg listener

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -245,6 +245,10 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     if (Utils.Object.hasPropertyPath(config, 'streaming')) {
       adapterConfig.forceBreakStall = Utils.Object.getPropertyPath(config, 'streaming.forceBreakStall');
       adapterConfig.lowLatencyMode = Utils.Object.getPropertyPath(config, 'streaming.lowLatencyMode');
+
+      if (Utils.Object.hasPropertyPath(config, 'streaming.trackEmsgEvents')) {
+        adapterConfig.trackEmsgEvents = Utils.Object.getPropertyPath(config, 'streaming.trackEmsgEvents');
+      }
     }
     if (Utils.Object.hasPropertyPath(config, 'sources.options')) {
       const options = config.sources.options;
@@ -272,6 +276,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     if (Utils.Object.hasPropertyPath(config, 'playback.options.html5.dash')) {
       Utils.Object.mergeDeep(adapterConfig.shakaConfig, config.playback.options.html5.dash);
 
+      //for backward compatibility with shaka version < 4
       if (Utils.Object.hasPropertyPath(adapterConfig.shakaConfig, 'manifest.dash.defaultPresentationDelay')) {
         adapterConfig.shakaConfig.manifest.defaultPresentationDelay = adapterConfig.shakaConfig.manifest.dash.defaultPresentationDelay;
         delete adapterConfig.shakaConfig.manifest.dash.defaultPresentationDelay;
@@ -738,13 +743,15 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._eventManager.listen(this._shaka, ShakaEvent.ADAPTATION, this._adapterEventsBindings.adaptation);
     this._eventManager.listen(this._shaka, ShakaEvent.ERROR, this._adapterEventsBindings.error);
     this._eventManager.listen(this._shaka, ShakaEvent.DRM_SESSION_UPDATE, this._adapterEventsBindings.drmsessionupdate);
-    this._eventManager.listen(this._shaka, ShakaEvent.EMSG, this._adapterEventsBindings.emsg);
     this._eventManager.listen(this._videoElement, EventType.WAITING, this._adapterEventsBindings.waiting);
     this._eventManager.listen(this._videoElement, EventType.PLAYING, this._adapterEventsBindings.playing);
     this._eventManager.listen(this._videoElement, EventType.LOADED_DATA, () => this._onLoadedData());
     this._eventManager.listenOnce(this._videoElement, EventType.PLAYING, () => {
       this._eventManager.listen(this._shaka, ShakaEvent.BUFFERING, this._adapterEventsBindings.buffering);
     });
+    if (this._config.trackEmsgEvents) {
+      this._eventManager.listen(this._shaka, ShakaEvent.EMSG, this._adapterEventsBindings.emsg);
+    }
 
     // called when a resource is downloaded
     this._shaka.getNetworkingEngine().registerResponseFilter((type, response) => {

--- a/src/default-config.json
+++ b/src/default-config.json
@@ -10,5 +10,6 @@
       "restrictions": {}
     }
   },
-  "forceRedirectExternalStreams": false
+  "forceRedirectExternalStreams": false,
+  "trackEmsgEvents": true
 }


### PR DESCRIPTION
### Description of the Changes

emsg metadata cues can take up a lot of memory because they contain binary data
this configuration allows toggling the emsg listener off if needed

resolves FEC-12615

related PR: https://github.com/kaltura/playkit-js/pull/668

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
