### PR TITLE
fix(FEC-12776): Dash Adapter does not support Default track from stream

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -1050,6 +1050,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
         id: textTrack.id,
         kind: kind,
         active: false,
+        default: textTrack.primary,
         label: textTrack.label,
         language: textTrack.language
       };


### PR DESCRIPTION
### Description of the Changes

See here [JSDoc: Class: shaka.extern](https://shaka-player-demo.appspot.com/docs/api/shaka.extern.html#.Track)
the Track.primary filed in dash parsed track (return form shaka.getTextTracks() API) indicates the default track
Which ignored by the adapter 
(Unlike Hls Adapter which handles default track which indicated by Track.default field there)

solves FEC-12776

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
