### PR TITLE
fix(FEC-13108): Start time can't be set to 0 in loadMedia for live with dvr

### DIFF
--- a/src/dash-adapter.js
+++ b/src/dash-adapter.js
@@ -863,7 +863,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       this._loadPromise = new Promise((resolve, reject) => {
         if (this._sourceObj && this._sourceObj.url) {
           this._trigger(EventType.ABR_MODE_CHANGED, {mode: this.isAdaptiveBitrateEnabled() ? 'auto' : 'manual'});
-          let shakaStartTime = startTime && startTime > -1 ? startTime : undefined;
+          let shakaStartTime = typeof startTime === 'number' && startTime > -1 ? startTime : undefined;
           shakaStartTime = isNaN(this._lastTimeDetach) ? shakaStartTime : this._lastTimeDetach;
           this._lastTimeDetach = NaN;
           this._maybeGetRedirectedUrl(this._sourceObj.url)


### PR DESCRIPTION
### Description of the Changes

Support setting startTime 0.
Resolves [FEC-13108](https://kaltura.atlassian.net/browse/FEC-13108).

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13108]: https://kaltura.atlassian.net/browse/FEC-13108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ