### PR TITLE
feat(FEC-13946): Player core - Use shaka preload mechanism during playlist playback 

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -41,7 +41,7 @@ module.exports = function (config) {
     client: {
       mocha: {
         reporter: 'html',
-        timeout: 5000
+        timeout: 50000
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "karma-webpack": "^5.0.0",
     "mocha": "^10.0.0",
     "prettier": "^3.0.3",
-    "shaka-player": "4.7.0",
+    "shaka-player": "4.8.4",
     "sinon": "^14.0.0",
     "sinon-chai": "^3.7.0",
     "standard-version": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@babel/runtime": "^7.23.6",
     "@microsoft/api-extractor": "^7.38.0",
     "@playkit-js/browserslist-config": "1.0.8",
-    "@playkit-js/playkit-js": "canary",
+    "@playkit-js/playkit-js": "0.84.10-canary.0-fa40833",
     "@types/chai": "^4.3.3",
     "@types/mocha": "^9.1.1",
     "@types/sinon": "^10.0.20",
@@ -89,7 +89,7 @@
     "webpack-dev-server": "^4.15.1"
   },
   "peerDependencies": {
-    "@playkit-js/playkit-js": "canary",
+    "@playkit-js/playkit-js": "0.84.10-canary.0-fa40833",
     "shaka-player": "4.7.0"
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "karma-webpack": "^5.0.0",
     "mocha": "^10.0.0",
     "prettier": "^3.0.3",
-    "shaka-player": "4.8.4",
+    "shaka-player": "4.8.11",
     "sinon": "^14.0.0",
     "sinon-chai": "^3.7.0",
     "standard-version": "^6.0.1",

--- a/src/cache/asset-cache.ts
+++ b/src/cache/asset-cache.ts
@@ -5,15 +5,12 @@ class AssetCache {
   private cache = new Map<string, any>();
 
   public init(shakaInstance: shaka.Player) {
-    // TODO when to reset shaka ? when video element is destroyed ?
-    this.shakaInstance = null;
     this.clearCache();
     this.shakaInstance = shakaInstance;
     this.preloadAssets();
   }
 
   public add(assetUrl: string) {
-    console.log('>>> asset cache add', assetUrl);
     if (this.cache.has(assetUrl)) return;
 
     this.cacheQueue.add(assetUrl);
@@ -21,15 +18,10 @@ class AssetCache {
   }
 
   public get(assetUrl: string): Promise<any> | null {
-    console.log('>>> asset cache get', assetUrl);
-
     return this.cache.get(assetUrl) || null;
   }
 
   public list(): string[] {
-    // if (this.cacheQueue.size) {
-    //   return [...this.cacheQueue];
-    // }
     return [...this.cache.keys()];
   }
 
@@ -55,7 +47,6 @@ class AssetCache {
   private preloadAssets() {
     if (!this.shakaInstance) return;
 
-    // TODO test this
     for (const assetUrl of this.cacheQueue) {
       this.cache.set(assetUrl, this.shakaInstance.preload(assetUrl));
       this.cacheQueue.delete(assetUrl);

--- a/src/cache/asset-cache.ts
+++ b/src/cache/asset-cache.ts
@@ -1,0 +1,68 @@
+class AssetCache {
+  private shakaInstance: shaka.Player | null = null;
+
+  private preloadQueue: string[] = [];
+  private preloadPromiseMap = new Map<string, any>();
+
+  public init(shakaInstance: shaka.Player) {
+    this.reset();
+    this.shakaInstance = shakaInstance;
+    this.preloadAssets();
+  }
+
+  public add(assetUrl: string) {
+    // TODO dont add the same url twice
+
+    this.preloadQueue.push(assetUrl);
+    this.preloadAssets();
+  }
+
+  public get(assetUrl: string): Promise<any> | null {
+    return this.preloadPromiseMap.get(assetUrl) || null;
+  }
+
+  public list(): string[] {
+    if (this.preloadQueue.length) {
+      return this.preloadQueue;
+    }
+    return [...this.preloadPromiseMap.keys()];
+  }
+
+  public remove(assetUrl: string, destroy: boolean = false) {
+    const index = this.preloadQueue.findIndex(item => item === assetUrl);
+    if (index !== -1) {
+      this.preloadQueue.splice(index, 1);
+    } else if (this.preloadPromiseMap.has(assetUrl)) {
+      const assetPromise = this.preloadPromiseMap.get(assetUrl);
+      // TODO
+      if (!destroy) {
+        assetPromise.then(loader => loader.destroy());
+      }
+      this.preloadPromiseMap.delete(assetUrl);
+    }
+  }
+
+  public removeAll() {
+    this.preloadQueue = [];
+    const assetUrls = this.preloadPromiseMap.keys();
+    for (const assetUrl of assetUrls) {
+      this.remove(assetUrl, true);
+    }
+  }
+
+  public reset() {
+    this.removeAll();
+    this.shakaInstance = null;
+  }
+
+  private preloadAssets() {
+    if (!this.shakaInstance) return;
+
+    while (this.preloadQueue.length) {
+      const assetUrl = this.preloadQueue.pop() as string;
+      this.preloadPromiseMap.set(assetUrl, this.shakaInstance.preload(assetUrl));
+    }
+  }
+}
+
+export {AssetCache};

--- a/src/cache/asset-cache.ts
+++ b/src/cache/asset-cache.ts
@@ -4,13 +4,13 @@ class AssetCache {
   private cacheQueue = new Set<string>();
   private cache = new Map<string, any>();
 
-  public init(shakaInstance: shaka.Player) {
+  public init(shakaInstance: shaka.Player): void {
     this.clearCache();
     this.shakaInstance = shakaInstance;
     this.preloadAssets();
   }
 
-  public add(assetUrl: string) {
+  public add(assetUrl: string): void {
     if (this.cache.has(assetUrl)) return;
 
     this.cacheQueue.add(assetUrl);
@@ -25,7 +25,7 @@ class AssetCache {
     return [...this.cache.keys()];
   }
 
-  public remove(assetUrl: string, destroy: boolean = false) {
+  public remove(assetUrl: string, destroy: boolean = false): void {
     if (this.cacheQueue.has(assetUrl)) {
       this.cacheQueue.delete(assetUrl);
     } else if (this.cache.has(assetUrl)) {
@@ -37,14 +37,14 @@ class AssetCache {
     }
   }
 
-  private clearCache() {
+  private clearCache(): void {
     const assetUrls = this.cache.keys();
     for (const assetUrl of assetUrls) {
       this.remove(assetUrl, true);
     }
   }
 
-  private preloadAssets() {
+  private preloadAssets(): void {
     if (!this.shakaInstance) return;
 
     for (const assetUrl of this.cacheQueue) {

--- a/src/cache/asset-cache.ts
+++ b/src/cache/asset-cache.ts
@@ -6,7 +6,8 @@ class AssetCache {
 
   public init(shakaInstance: shaka.Player) {
     // TODO when to reset shaka ? when video element is destroyed ?
-    this.reset();
+    this.shakaInstance = null;
+    this.clearCache();
     this.shakaInstance = shakaInstance;
     this.preloadAssets();
   }
@@ -26,9 +27,9 @@ class AssetCache {
   }
 
   public list(): string[] {
-    if (this.cacheQueue.size) {
-      return [...this.cacheQueue];
-    }
+    // if (this.cacheQueue.size) {
+    //   return [...this.cacheQueue];
+    // }
     return [...this.cache.keys()];
   }
 
@@ -38,23 +39,17 @@ class AssetCache {
     } else if (this.cache.has(assetUrl)) {
       const assetPromise = this.cache.get(assetUrl);
       if (destroy) {
-        assetPromise.then(loader => loader.destroy());
+        assetPromise.then(preloadMgr => preloadMgr.destroy());
       }
       this.cache.delete(assetUrl);
     }
   }
 
-  public removeAll() {
-    this.cacheQueue.clear();
+  private clearCache() {
     const assetUrls = this.cache.keys();
     for (const assetUrl of assetUrls) {
       this.remove(assetUrl, true);
     }
-  }
-
-  public reset() {
-    this.removeAll();
-    this.shakaInstance = null;
   }
 
   private preloadAssets() {

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -790,28 +790,28 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     // called when a resource is downloaded
     this.shaka!.getNetworkingEngine()?.registerResponseFilter((type, response) => {
       switch (type) {
-        case shaka.net.NetworkingEngine.RequestType.SEGMENT:
-          this._trigger(EventType.FRAG_LOADED, {
-            miliSeconds: response.timeMs,
-            bytes: response.data.byteLength,
-            url: response.uri
-          });
-          if (this.isLive()) {
-            this._dispatchNativeEvent(EventType.DURATION_CHANGE);
-          }
-          break;
-        case shaka.net.NetworkingEngine.RequestType.MANIFEST:
-          this._parseManifest(response.data);
-          this._playbackActualUri = response.uri;
-          this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
-          setTimeout(() => {
-            this._isLive = this._isLive || (this.shaka?.isLive() as boolean);
-            if (this._isLive && !this.shaka?.isLive() && !this._isStaticLive && this._config.switchDynamicToStatic) {
+      case shaka.net.NetworkingEngine.RequestType.SEGMENT:
+        this._trigger(EventType.FRAG_LOADED, {
+          miliSeconds: response.timeMs,
+          bytes: response.data.byteLength,
+          url: response.uri
+        });
+        if (this.isLive()) {
+          this._dispatchNativeEvent(EventType.DURATION_CHANGE);
+        }
+        break;
+      case shaka.net.NetworkingEngine.RequestType.MANIFEST:
+        this._parseManifest(response.data);
+        this._playbackActualUri = response.uri;
+        this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
+        setTimeout(() => {
+          this._isLive = this._isLive || (this.shaka?.isLive() as boolean);
+          if (this._isLive && !this.shaka?.isLive() && !this._isStaticLive && this._config.switchDynamicToStatic) {
               this._sourceObj!.url = response.uri;
               this._switchFromDynamicToStatic();
-            }
-          });
-          break;
+          }
+        });
+        break;
       }
     });
   }

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -897,13 +897,13 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
           this._lastTimeDetach = NaN;
           this._maybeGetRedirectedUrl(this._sourceObj.url)
             .then(async url => {
-              debugger;
               const assetPromise = DashAdapter._assetCache.get(url);
               if (!assetPromise) {
                 return this._shaka.load(url, shakaStartTime);
               } else {
                 DashAdapter._assetCache.remove(url);
-                return this._shaka.load(await assetPromise, shakaStartTime);
+                const preloadMgr = await assetPromise;
+                return this._shaka.load(preloadMgr, shakaStartTime);
               }
             })
             .then(() => {

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -514,11 +514,12 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   }
 
   private _maybeSetFilters(): void {
+    this.shaka!.getNetworkingEngine()?.clearAllRequestFilters();
+    this.shaka!.getNetworkingEngine()?.clearAllResponseFilters();
+
     if (typeof Utils.Object.getPropertyPath(this._config, 'network.requestFilter') === 'function') {
       DashAdapter._logger.debug('Register request filter');
 
-      this.shaka!.getNetworkingEngine()?.clearAllRequestFilters();
-      this.shaka!.getNetworkingEngine()?.clearAllResponseFilters();
       this.shaka!.getNetworkingEngine()?.registerRequestFilter((type, request) => {
         if (Object.values(RequestType).includes(type)) {
           const pkRequest: PKRequestObject = {url: request.uris[0], body: request.body, headers: request.headers};
@@ -707,7 +708,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @returns {Promise<void>} - detach promise
    */
   public detachMediaSource(): Promise<void> {
-    if (this.shaka!) {
+    if (this.shaka) {
       // 1 second different between duration and current time will signal as end - will enable replay button
       // @ts-expect-error - ????
       if (Math.floor(this.duration - this.currentTime) === 0) {
@@ -937,8 +938,8 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._isDestroyInProgress = true;
 
     let shakaInstanceToDestroy;
-    if (this.shaka! && !this.assetCache?.list().length) {
-      shakaInstanceToDestroy = this.shaka!;
+    if (this.shaka && !this.assetCache?.list().length) {
+      shakaInstanceToDestroy = this.shaka;
 
       DashAdapter._shakaInstanceMap.delete(this._videoElement.id);
       DashAdapter._assetCacheMap.delete(this._videoElement.id);
@@ -1075,7 +1076,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   private _getParsedTracks(): Array<Track> {
-    if (this.shaka!) {
+    if (this.shaka) {
       const videoTracks = this._getParsedVideoTracks();
       const audioTracks = this._getParsedAudioTracks();
       const textTracks = this._getParsedTextTracks();
@@ -1182,7 +1183,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   public selectVideoTrack(videoTrack: VideoTrack): void {
-    if (this.shaka!) {
+    if (this.shaka) {
       const videoTracks = this._getVideoTracks();
       if (videoTrack instanceof VideoTrack && videoTracks) {
         const selectedVideoTrack = videoTracks[videoTrack.index];
@@ -1209,7 +1210,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   public selectAudioTrack(audioTrack: AudioTrack): void {
-    if (this.shaka! && audioTrack instanceof AudioTrack && !audioTrack.active) {
+    if (this.shaka && audioTrack instanceof AudioTrack && !audioTrack.active) {
       this.shaka!.selectAudioLanguage(audioTrack.language);
       this._onTrackChanged(audioTrack);
     }
@@ -1223,7 +1224,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   public selectTextTrack(textTrack: PKTextTrack): void {
-    if (this.shaka! && textTrack instanceof PKTextTrack && !textTrack.active && (textTrack.kind === 'subtitles' || textTrack.kind === 'captions')) {
+    if (this.shaka && textTrack instanceof PKTextTrack && !textTrack.active && (textTrack.kind === 'subtitles' || textTrack.kind === 'captions')) {
       this.shaka!.setTextTrackVisibility(this._config.textTrackVisibile);
       this.shaka!.selectTextLanguage(textTrack.language);
       this._onTrackChanged(textTrack);
@@ -1231,7 +1232,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   }
 
   public selectImageTrack(imageTrack: ImageTrack): void {
-    if (this.shaka! && this._thumbnailController && imageTrack instanceof ImageTrack && !imageTrack.active) {
+    if (this.shaka && this._thumbnailController && imageTrack instanceof ImageTrack && !imageTrack.active) {
       this._thumbnailController.selectTrack(imageTrack);
       this._onTrackChanged(imageTrack);
     }
@@ -1244,7 +1245,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   public hideTextTrack(): void {
-    if (this.shaka!) {
+    if (this.shaka) {
       this.shaka!.setTextTrackVisibility(false);
     }
   }
@@ -1256,7 +1257,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   public enableAdaptiveBitrate(): void {
-    if (this.shaka! && !this.isAdaptiveBitrateEnabled()) {
+    if (this.shaka && !this.isAdaptiveBitrateEnabled()) {
       this._trigger(EventType.ABR_MODE_CHANGED, {mode: 'auto'});
       this.shaka!.configure({abr: {enabled: true}});
     }
@@ -1269,7 +1270,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   public isAdaptiveBitrateEnabled(): boolean {
-    if (this.shaka!) {
+    if (this.shaka) {
       const shakaConfig = this.shaka!.getConfiguration();
       return shakaConfig.abr.enabled;
     }
@@ -1314,7 +1315,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @public
    */
   public seekToLiveEdge(): void {
-    if (this.shaka! && this._videoElement.readyState > 0) {
+    if (this.shaka && this._videoElement.readyState > 0) {
       this._videoElement.currentTime = this._getLiveEdge();
     }
   }
@@ -1342,7 +1343,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @return {number} - live duration
    */
   public getSegmentDuration(): number {
-    if (this.shaka!) {
+    if (this.shaka) {
       return this.shaka!.getStats().maxSegmentDuration;
     }
     return 0;

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -790,28 +790,28 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     // called when a resource is downloaded
     this.shaka!.getNetworkingEngine()?.registerResponseFilter((type, response) => {
       switch (type) {
-      case shaka.net.NetworkingEngine.RequestType.SEGMENT:
-        this._trigger(EventType.FRAG_LOADED, {
-          miliSeconds: response.timeMs,
-          bytes: response.data.byteLength,
-          url: response.uri
-        });
-        if (this.isLive()) {
-          this._dispatchNativeEvent(EventType.DURATION_CHANGE);
-        }
-        break;
-      case shaka.net.NetworkingEngine.RequestType.MANIFEST:
-        this._parseManifest(response.data);
-        this._playbackActualUri = response.uri;
-        this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
-        setTimeout(() => {
-          this._isLive = this._isLive || (this.shaka?.isLive() as boolean);
-          if (this._isLive && !this.shaka?.isLive() && !this._isStaticLive && this._config.switchDynamicToStatic) {
+        case shaka.net.NetworkingEngine.RequestType.SEGMENT:
+          this._trigger(EventType.FRAG_LOADED, {
+            miliSeconds: response.timeMs,
+            bytes: response.data.byteLength,
+            url: response.uri
+          });
+          if (this.isLive()) {
+            this._dispatchNativeEvent(EventType.DURATION_CHANGE);
+          }
+          break;
+        case shaka.net.NetworkingEngine.RequestType.MANIFEST:
+          this._parseManifest(response.data);
+          this._playbackActualUri = response.uri;
+          this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
+          setTimeout(() => {
+            this._isLive = this._isLive || (this.shaka?.isLive() as boolean);
+            if (this._isLive && !this.shaka?.isLive() && !this._isStaticLive && this._config.switchDynamicToStatic) {
               this._sourceObj!.url = response.uri;
               this._switchFromDynamicToStatic();
-          }
-        });
-        break;
+            }
+          });
+          break;
       }
     });
   }
@@ -939,19 +939,25 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   public destroy(): Promise<void> {
     this._isDestroyInProgress = true;
 
-    let shakaInstanceToDestroy;
-    if (this.shaka) {
-      this.shaka.unload();
+    return new Promise(async (resolve, reject) => {
+      let shakaInstanceToDestroy;
 
-      if (!this.assetCache?.list().length) {
-        shakaInstanceToDestroy = this.shaka;
+      if (this.shaka) {
+        // explicitly pass undefined to restore the default drm configuration
+        this.shaka.configure('drm', undefined);
 
-        DashAdapter._shakaInstanceMap.delete(this._videoElement.id);
-        DashAdapter._assetCacheMap.delete(this._videoElement.id);
+        if (this.assetCache?.list().length) {
+          if (this._videoElement.src) {
+            await this.shaka.unload();
+          }
+          await this.shaka.detach();
+        } else {
+          shakaInstanceToDestroy = this.shaka;
+          DashAdapter._shakaInstanceMap.delete(this._videoElement.id);
+          DashAdapter._assetCacheMap.delete(this._videoElement.id);
+        }
       }
-    }
 
-    return new Promise((resolve, reject) => {
       super.destroy().then(() => {
         DashAdapter._logger.debug('destroy');
         this._loadPromise = undefined;

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -1562,7 +1562,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     }
   }
 
-  public setCachedUrls(cachedUrls: string[]) {
+  public setCachedUrls(cachedUrls: string[]): void {
     if (!Array.isArray(cachedUrls)) return;
     const newUrls = new Set(cachedUrls);
     const existingUrls = new Set(this.assetCache?.list());
@@ -1578,7 +1578,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     }
   }
 
-  private get assetCache() {
+  private get assetCache(): AssetCache | null {
     const assetCache = DashAdapter._assetCacheMap.get(this._videoElement.id);
     if (!assetCache) {
       DashAdapter._logger.warn('Failed to fetch asset cache for video element ', this._videoElement.id);
@@ -1587,7 +1587,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     return assetCache;
   }
 
-  private get shaka() {
+  private get shaka(): shaka.Player | null {
     const shakaInstance = DashAdapter._shakaInstanceMap.get(this._videoElement.id);
     if (!shakaInstance) {
       DashAdapter._logger.warn('Failed to fetch shaka instance for video element ', this._videoElement.id);

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -940,11 +940,15 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._isDestroyInProgress = true;
 
     let shakaInstanceToDestroy;
-    if (this.shaka && !this.assetCache?.list().length) {
-      shakaInstanceToDestroy = this.shaka;
+    if (this.shaka) {
+      this.shaka.unload();
 
-      DashAdapter._shakaInstanceMap.delete(this._videoElement.id);
-      DashAdapter._assetCacheMap.delete(this._videoElement.id);
+      if (!this.assetCache?.list().length) {
+        shakaInstanceToDestroy = this.shaka;
+
+        DashAdapter._shakaInstanceMap.delete(this._videoElement.id);
+        DashAdapter._assetCacheMap.delete(this._videoElement.id);
+      }
     }
 
     return new Promise((resolve, reject) => {

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -1563,17 +1563,18 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   }
 
   public setCachedUrls(cachedUrls: string[]): void {
-    if (!Array.isArray(cachedUrls)) return;
-    const newUrls = new Set(cachedUrls);
-    const existingUrls = new Set(this.assetCache?.list());
-    for (const url of newUrls) {
-      if (!existingUrls.has(url)) {
-        this.assetCache?.add(url);
+    if (!Array.isArray(cachedUrls) || !this.assetCache) return;
+
+    const existingUrls = this.assetCache.list();
+
+    for (const url of cachedUrls) {
+      if (!existingUrls.includes(url)) {
+        this.assetCache.add(url);
       }
     }
     for (const url of existingUrls) {
-      if (!newUrls.has(url)) {
-        this.assetCache?.remove(url, true);
+      if (!cachedUrls.includes(url)) {
+        this.assetCache.remove(url, true);
       }
     }
   }

--- a/tests/src/cache/asset-cache.spec.js
+++ b/tests/src/cache/asset-cache.spec.js
@@ -153,5 +153,23 @@ describe.only('AssetCache', () => {
             });
         });
     });
-    // describe('init');
+    describe.only('init', () => {
+        it('should add queued items to cache', () => {
+            const preload = sinon.stub(shakaInstance, "preload").resolves({});
+            assetCache.add("abc");
+            assetCache.add("def");
+            expect(assetCache.list().length).to.equal(0);
+            assetCache.init(shakaInstance);
+            expect(assetCache.list().length).to.equal(2);
+        });
+        it('should remove all items from cache', () => {
+            const preload = sinon.stub(shakaInstance, "preload").resolves({});
+            assetCache.init(shakaInstance);
+            assetCache.add("abc");
+            assetCache.add("def");
+            expect(assetCache.list().length).to.equal(2);
+            assetCache.init(shakaInstance);
+            expect(assetCache.list().length).to.equal(0);
+        });
+    });
 });

--- a/tests/src/cache/asset-cache.spec.js
+++ b/tests/src/cache/asset-cache.spec.js
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import { AssetCache } from "../../../src/cache/asset-cache";
 
-describe.only('AssetCache', () => {
+describe('AssetCache', () => {
     let assetCache, shakaInstance;
     
     beforeEach(() => {
@@ -153,7 +153,7 @@ describe.only('AssetCache', () => {
             });
         });
     });
-    describe.only('init', () => {
+    describe('init', () => {
         it('should add queued items to cache', () => {
             const preload = sinon.stub(shakaInstance, "preload").resolves({});
             assetCache.add("abc");

--- a/tests/src/cache/asset-cache.spec.js
+++ b/tests/src/cache/asset-cache.spec.js
@@ -1,0 +1,70 @@
+import { AssetCache } from "../../../src/cache/asset-cache";
+
+describe.only('AssetCache', () => {
+    let assetCache, shakaInstance;
+
+    beforeEach(() => {
+        assetCache = new AssetCache();
+        shakaInstance = {
+            preload: () => {},
+            destroy: () => {}
+        }
+    });
+    afterEach(() => {
+        assetCache = null;
+        sinon.restore();
+    });
+
+    describe('get', () => {
+        let get;
+        beforeEach(() => {
+            get = sinon.spy(assetCache, "get");
+        });
+        it('should return null if asset was not added', () => {
+            expect(assetCache.get("abc")).to.equal(null);
+        });
+        it('should return null if asset was added but shaka is not set', () => {
+            assetCache.add("abc");
+            expect(assetCache.get("abc")).to.equal(null);
+        });
+        it('should return the asset promise if asset was added and shaka is set', done => {
+            sinon.stub(shakaInstance, "preload").resolves("def");
+            assetCache.init(shakaInstance);
+            assetCache.add("abc");
+            assetCache.get("abc").then(result => {
+                expect(result).to.equal("def");
+                done();
+            });
+        })
+    });
+
+    describe('list', () => {
+        it('should list all queued assets, without duplicates, if shaka is not set', () => {
+            assetCache.add("abc");
+            assetCache.add("abc");
+            assetCache.add("def");
+
+            const listResult = assetCache.list();
+            expect(listResult.length).to.equal(2);
+            expect(listResult.findIndex(i => i === "abc")).to.not.equal(-1);
+            expect(listResult.findIndex(i => i === "def")).to.not.equal(-1);
+        });
+        it('should list all cached assets, without duplicates, if shaka is set', () => {
+            sinon.stub(shakaInstance, "preload").resolves({});
+            assetCache.init(shakaInstance);
+
+            assetCache.add("abc");
+            assetCache.add("abc");
+            assetCache.add("def");
+
+            const listResult = assetCache.list();
+            expect(listResult.length).to.equal(2);
+            expect(listResult.findIndex(i => i === "abc")).to.not.equal(-1);
+            expect(listResult.findIndex(i => i === "def")).to.not.equal(-1);
+        });
+    })
+
+    // describe('remove');
+    // describe('removeAll');
+    // describe('reset');
+});

--- a/tests/src/dash-adapter.spec.js
+++ b/tests/src/dash-adapter.spec.js
@@ -40,7 +40,7 @@ const dvrInStreamThumbnailSource = {
 describe.skip('DashAdapter [debugging and testing manually]', () => {
   let player, tracks, videoTracks, textTracks, audioTracks;
 
-  before(function () {
+  before(() => {
     TestUtils.createElement('DIV', targetId);
   });
 
@@ -92,7 +92,7 @@ describe('DashAdapter: canPlayDrm', () => {
     sandbox.restore();
   });
 
-  it('should return true since widevine configured', function () {
+  it('should return true since widevine configured', () => {
     sandbox.stub(Widevine, 'canPlayDrm').value(() => true);
     sandbox.stub(Widevine, 'isConfigured').value(() => true);
     sandbox.stub(PlayReady, 'canPlayDrm').value(() => false);
@@ -102,7 +102,7 @@ describe('DashAdapter: canPlayDrm', () => {
     (DashAdapter._availableDrmProtocol.find(entry => entry === Widevine) !== null).should.be.true;
   });
 
-  it('should return true since playready configured', function () {
+  it('should return true since playready configured', () => {
     sandbox.stub(Widevine, 'canPlayDrm').value(() => false);
     sandbox.stub(Widevine, 'isConfigured').value(() => false);
     sandbox.stub(PlayReady, 'canPlayDrm').value(() => true);
@@ -112,21 +112,21 @@ describe('DashAdapter: canPlayDrm', () => {
     (DashAdapter._availableDrmProtocol.find(entry => entry === PlayReady) !== null).should.be.true;
   });
 
-  it('should return true for widevine and playready sources without config', function () {
+  it('should return true for widevine and playready sources without config', () => {
     sandbox.stub(Widevine, 'isConfigured').value(() => false);
     sandbox.stub(PlayReady, 'isConfigured').value(() => false);
     DashAdapter.canPlayDrm(wwDrmData.concat(prDrmData)).should.be.true;
     DashAdapter._availableDrmProtocol.length.should.equal(2);
   });
 
-  it('should return true for widevine source only', function () {
+  it('should return true for widevine source only', () => {
     sandbox.stub(Widevine, 'isConfigured').value(() => false);
     sandbox.stub(PlayReady, 'isConfigured').value(() => false);
     DashAdapter.canPlayDrm(wwDrmData).should.be.true;
     DashAdapter._availableDrmProtocol.length.should.equal(1);
   });
 
-  it('should return true for playready source only', function () {
+  it('should return true for playready source only', () => {
     sandbox.stub(Widevine, 'isConfigured').value(() => false);
     sandbox.stub(PlayReady, 'isConfigured').value(() => false);
     DashAdapter.canPlayDrm(prDrmData).should.be.true;
@@ -143,35 +143,35 @@ describe('DashAdapter: canPlayType', () => {
     DashAdapter.canPlayType('APPLICATION/DASH+XML').should.be.true;
   });
 
-  it('should return false to video/mp4', function () {
+  it('should return false to video/mp4', () => {
     DashAdapter.canPlayType('video/mp4').should.be.false;
   });
 
-  it('should return false to invalid mimetype', function () {
+  it('should return false to invalid mimetype', () => {
     DashAdapter.canPlayType('dummy').should.be.false;
   });
 
-  it('should return false to null mimetype', function () {
+  it('should return false to null mimetype', () => {
     DashAdapter.canPlayType(null).should.be.false;
   });
 
-  it('should return false to empty mimetype', function () {
+  it('should return false to empty mimetype', () => {
     DashAdapter.canPlayType('').should.be.false;
   });
 
-  it('should return false to no mimetype', function () {
+  it('should return false to no mimetype', () => {
     DashAdapter.canPlayType().should.be.false;
   });
 });
 
 describe('DashAdapter: isSupported', () => {
-  it('should return true', function () {
+  it('should return true', () => {
     DashAdapter.isSupported().should.be.true;
   });
 });
 
 describe('DashAdapter: id', () => {
-  it('should be named DashAdapter', function () {
+  it('should be named DashAdapter', () => {
     DashAdapter.id.should.equal('DashAdapter');
   });
 });
@@ -411,7 +411,7 @@ describe('DashAdapter: targetBuffer', () => {
         Utils.Object.mergeDeep(config, {playback: {options: {html5: {dash: {streaming: {bufferingGoal: 120}}}}}})
       );
       video.addEventListener(EventType.PLAYING, () => {
-        let targetBufferVal = dashInstance._getLiveEdge() - video.currentTime;
+        const targetBufferVal = dashInstance._getLiveEdge() - video.currentTime;
         Math.round(dashInstance.targetBuffer - targetBufferVal).should.equal(0);
         done();
       });
@@ -432,7 +432,7 @@ describe('DashAdapter: targetBuffer', () => {
         Utils.Object.mergeDeep(config, {playback: {options: {html5: {dash: {streaming: {bufferingGoal: 10}}}}}})
       );
       video.addEventListener(EventType.PLAYING, () => {
-        let targetBufferVal = dashInstance._getLiveEdge() - video.currentTime;
+        const targetBufferVal = dashInstance._getLiveEdge() - video.currentTime;
         Math.round(dashInstance.targetBuffer - targetBufferVal).should.equal(0);
         done();
       });
@@ -455,15 +455,19 @@ describe('DashAdapter: destroy', () => {
     dashInstance = DashAdapter.createAdapter(video, vodSource, config);
   });
 
-  afterEach(() => {
-    dashInstance = null;
+  afterEach(done => {
+    dashInstance.setCachedUrls([]);
+    dashInstance.destroy().then(() => {
+      dashInstance = null;
+      done();
+    })
   });
 
-  after(function () {
+  after(() => {
     TestUtils.removeVideoElementsFromTestPage();
   });
 
-  it('should preform cleanup', done => {
+  it('should perform cleanup', done => {
     dashInstance
       .load()
       .then(() => {
@@ -501,15 +505,15 @@ describe('DashAdapter: destroy', () => {
   });
 
   it('should destroy shaka instance if there are no cached urls', done => {
-    const destroy = sinon.spy(dashInstance.shaka, "destroy");
+    const destroy = sinon.spy(dashInstance.shaka, 'destroy');
     dashInstance.destroy().then(() => {
       destroy.should.have.been.calledOnce;
       done();
     });
   });
   it('should not destroy shaka instance if there are cached urls', done => {
-    const destroy = sinon.spy(dashInstance.shaka, "destroy");
-    dashInstance.setCachedUrls(["abc"]);
+    const destroy = sinon.spy(dashInstance.shaka, 'destroy');
+    dashInstance.setCachedUrls(['abc']);
     dashInstance.destroy().then(() => {
       destroy.should.not.have.been.called;
       done();
@@ -546,10 +550,10 @@ describe('DashAdapter: _getParsedTracks', () => {
     dashInstance
       .load()
       .then(data => {
-        let videoTracks = dashInstance._getVideoTracks();
-        let audioTracks = dashInstance._getAudioTracks();
-        let textTracks = dashInstance.shaka.getTextTracks();
-        let totalTracksLength = videoTracks.length + audioTracks.length + textTracks.length;
+        const videoTracks = dashInstance._getVideoTracks();
+        const audioTracks = dashInstance._getAudioTracks();
+        const textTracks = dashInstance.shaka.getTextTracks();
+        const totalTracksLength = videoTracks.length + audioTracks.length + textTracks.length;
         try {
           data.tracks.length.should.be.equal(totalTracksLength);
           data.tracks.map(track => {
@@ -582,7 +586,7 @@ describe('DashAdapter: _getParsedTracks', () => {
   });
 
   it('should return empty array before loading', () => {
-    let tracks = dashInstance._getParsedTracks();
+    const tracks = dashInstance._getParsedTracks();
     tracks.length.should.be.equal(0);
   });
 });
@@ -640,7 +644,7 @@ describe('DashAdapter: selectVideoTrack', () => {
   it('should select a new video track', done => {
     let error = false;
     let inactiveTrack;
-    let onVideoTrackChanged = event => {
+    const onVideoTrackChanged = event => {
       try {
         if (!error) {
           dashInstance.removeEventListener('videotrackchanged', onVideoTrackChanged);
@@ -659,7 +663,7 @@ describe('DashAdapter: selectVideoTrack', () => {
           return !track.active;
         })[0];
         dashInstance.selectVideoTrack(inactiveTrack);
-        let activeTrack = dashInstance._getVideoTracks().filter(track => {
+        const activeTrack = dashInstance._getVideoTracks().filter(track => {
           return track.active;
         })[0];
         try {
@@ -680,7 +684,7 @@ describe('DashAdapter: selectVideoTrack', () => {
       dashInstance.addEventListener('videotrackchanged', () => {
         eventIsFired = true;
       });
-      let activeTrack = dashInstance._getParsedVideoTracks().filter(track => {
+      const activeTrack = dashInstance._getParsedVideoTracks().filter(track => {
         return track.active;
       })[0];
       let eventIsFired = false;
@@ -702,7 +706,7 @@ describe('DashAdapter: selectVideoTrack', () => {
       dashInstance.addEventListener('videotrackchanged', () => {
         eventIsFired = true;
       });
-      let activeTrack = dashInstance._getParsedVideoTracks().filter(track => {
+      const activeTrack = dashInstance._getParsedVideoTracks().filter(track => {
         return track.active;
       })[0];
       let eventIsFired = false;
@@ -724,7 +728,7 @@ describe('DashAdapter: selectVideoTrack', () => {
       dashInstance.addEventListener('videotrackchanged', () => {
         eventIsFired = true;
       });
-      let activeTrack = dashInstance._getParsedVideoTracks().filter(track => {
+      const activeTrack = dashInstance._getParsedVideoTracks().filter(track => {
         return track.active;
       })[0];
       let eventIsFired = false;
@@ -746,7 +750,7 @@ describe('DashAdapter: selectVideoTrack', () => {
       dashInstance.addEventListener('videotrackchanged', () => {
         eventIsFired = true;
       });
-      let activeTrack = dashInstance._getParsedVideoTracks().filter(track => {
+      const activeTrack = dashInstance._getParsedVideoTracks().filter(track => {
         return track.active;
       })[0];
       let eventIsFired = false;
@@ -796,7 +800,7 @@ describe('DashAdapter: selectAudioTrack', () => {
             done(e);
           }
         });
-        let inactiveTrack = dashInstance._getParsedAudioTracks().filter(track => {
+        const inactiveTrack = dashInstance._getParsedAudioTracks().filter(track => {
           return !track.active;
         })[0];
         dashInstance.selectAudioTrack(inactiveTrack);
@@ -935,11 +939,11 @@ describe('DashAdapter: selectTextTrack', () => {
         event.payload.selectedTextTrack.language.should.be.equal(inactiveTrack.language);
         done();
       });
-      let inactiveTrack = dashInstance._getParsedTextTracks().filter(track => {
+      const inactiveTrack = dashInstance._getParsedTextTracks().filter(track => {
         return !track.active;
       })[0];
       dashInstance.selectTextTrack(inactiveTrack);
-      let activeTrack = dashInstance.shaka.getTextTracks().filter(track => {
+      const activeTrack = dashInstance.shaka.getTextTracks().filter(track => {
         return track.active;
       })[0];
       activeTrack.language.should.be.equal(inactiveTrack.language);
@@ -953,7 +957,7 @@ describe('DashAdapter: selectTextTrack', () => {
         eventCounter++;
         activeTrack.active = true;
       });
-      let activeTrack = dashInstance._getParsedTextTracks()[0];
+      const activeTrack = dashInstance._getParsedTextTracks()[0];
       dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack(activeTrack);
       activeTrack.language.should.be.equal(
@@ -975,7 +979,7 @@ describe('DashAdapter: selectTextTrack', () => {
         eventCounter++;
         activeTrack.active = true;
       });
-      let activeTrack = dashInstance._getParsedTextTracks()[0];
+      const activeTrack = dashInstance._getParsedTextTracks()[0];
       dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack(new VideoTrack({index: 0}));
       activeTrack.language.should.be.equal(
@@ -997,7 +1001,7 @@ describe('DashAdapter: selectTextTrack', () => {
         eventCounter++;
         activeTrack.active = true;
       });
-      let activeTrack = dashInstance._getParsedTextTracks()[0];
+      const activeTrack = dashInstance._getParsedTextTracks()[0];
       dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack();
       activeTrack.language.should.be.equal(
@@ -1019,7 +1023,7 @@ describe('DashAdapter: selectTextTrack', () => {
         eventCounter++;
         activeTrack.active = true;
       });
-      let activeTrack = dashInstance._getParsedTextTracks()[0];
+      const activeTrack = dashInstance._getParsedTextTracks()[0];
       dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack(new TextTrack({kind: 'metadata'}));
       activeTrack.language.should.be.equal(
@@ -1086,7 +1090,7 @@ describe('DashAdapter: enableAdaptiveBitrate', () => {
       .then(() => {
         mode = 'auto';
         dashInstance.enableAdaptiveBitrate();
-        let inactiveTrack = dashInstance._getParsedVideoTracks().filter(track => {
+        const inactiveTrack = dashInstance._getParsedVideoTracks().filter(track => {
           return !track.active;
         })[0];
         mode = 'manual';
@@ -1312,7 +1316,7 @@ describe('DashAdapter: _onBuffering', () => {
   it('should dispatch playing event when buffering is false and video is playing after waiting event', done => {
     dashInstance = DashAdapter.createAdapter(video, vodSource, config);
     let hasPlaying = false;
-    let onPlaying = () => {
+    const onPlaying = () => {
       if (hasPlaying) {
         dashInstance._videoElement.removeEventListener(EventType.PLAYING, onPlaying);
         done();
@@ -1340,7 +1344,7 @@ describe('DashAdapter: _onBuffering', () => {
   it('should not dispatch playing event when buffering is false and video is playing but it has already been sent by the video element', done => {
     dashInstance = DashAdapter.createAdapter(video, vodSource, config);
     sandbox.stub(dashInstance._videoElement, 'paused').get(() => false);
-    let t = setTimeout(done, 0);
+    const t = setTimeout(done, 0);
     dashInstance._videoElement.addEventListener(EventType.PLAYING, () => {
       done(new Error('test fail'));
       clearTimeout(t);
@@ -1351,7 +1355,7 @@ describe('DashAdapter: _onBuffering', () => {
 
   it('should not dispatch playing event when buffering is false but video is paused', done => {
     dashInstance = DashAdapter.createAdapter(video, vodSource, config);
-    let t = setTimeout(done, 0);
+    const t = setTimeout(done, 0);
     dashInstance._videoElement.addEventListener(EventType.PLAYING, () => {
       done(new Error('test fail'));
       clearTimeout(t);
@@ -1388,7 +1392,7 @@ describe('DashAdapter: _onPlaying', () => {
 
   it('should not dispatch waiting event when buffering is false', done => {
     dashInstance = DashAdapter.createAdapter(video, vodSource, config);
-    let t = setTimeout(done, 0);
+    const t = setTimeout(done, 0);
     dashInstance._videoElement.addEventListener(EventType.WAITING, () => {
       done(new Error('test fail'));
       clearTimeout(t);
@@ -1974,15 +1978,15 @@ describe('DashAdapter: setCachedUrls', () => {
   let video, config, sandbox, dashInstance;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();  
-    
+    sandbox = sinon.createSandbox();
+
     video = document.createElement('video');
     video.id = `test_id_${Date.now()}`;
-    
+
     config = {playback: {options: {html5: {dash: {}}}}};
 
     dashInstance = DashAdapter.createAdapter(video, vodSource, config);
-    sandbox.stub(dashInstance.shaka, "preload").resolves("def");
+    sandbox.stub(dashInstance.shaka, 'preload').resolves('def');
   });
 
   afterEach(() => {
@@ -1996,66 +2000,66 @@ describe('DashAdapter: setCachedUrls', () => {
   describe('setCachedUrls setting', () => {
 
     describe('on initial call', () => {
-      let add; 
+      let add;
 
       beforeEach(() => {
-        add = sandbox.spy(dashInstance.assetCache, "add");
+        add = sandbox.spy(dashInstance.assetCache, 'add');
       });
-  
+
       it('should not cache asset url on empty call', () => {
         dashInstance.setCachedUrls([]);
         add.should.not.have.been.called;
       });
 
       it('should not add loaders on non-array call', () => {
-        dashInstance.setCachedUrls("abc");
+        dashInstance.setCachedUrls('abc');
         add.should.not.have.been.called;
       });
 
       it('should cache asset url on array call', () => {
-        dashInstance.setCachedUrls(["abc"]);
-        add.should.have.been.calledOnceWith("abc");        
+        dashInstance.setCachedUrls(['abc']);
+        add.should.have.been.calledOnceWith('abc');
       })
     });
 
-    describe("on consecutive calls", () => {
+    describe('on consecutive calls', () => {
       let add, remove;
 
       beforeEach(() => {
-        add = sandbox.spy(dashInstance.assetCache, "add");
-        remove = sandbox.stub(dashInstance.assetCache, "remove");
+        add = sandbox.spy(dashInstance.assetCache, 'add');
+        remove = sandbox.stub(dashInstance.assetCache, 'remove');
       });
 
-      it("should not add the same url twice on a consecutive call", () => {
-        dashInstance.setCachedUrls(["abc"]);
-        dashInstance.setCachedUrls(["abc"]);
-        add.should.have.been.calledOnceWith("abc");   
+      it('should not add the same url twice on a consecutive call', () => {
+        dashInstance.setCachedUrls(['abc']);
+        dashInstance.setCachedUrls(['abc']);
+        add.should.have.been.calledOnceWith('abc');
       });
 
-      it("should add new urls on a consecutive call", () => {
-        dashInstance.setCachedUrls(["abc"]);
-        add.should.have.been.calledWith("abc");  
-        dashInstance.setCachedUrls(["abc", "def"]);
-        add.should.have.been.calledWith("def");  
+      it('should add new urls on a consecutive call', () => {
+        dashInstance.setCachedUrls(['abc']);
+        add.should.have.been.calledWith('abc');
+        dashInstance.setCachedUrls(['abc', 'def']);
+        add.should.have.been.calledWith('def');
       });
 
-      it("should remove asset urls that were initially added and are missing on a consecutive call", () => {
-        dashInstance.setCachedUrls(["abc"]);
-        add.should.have.been.calledWith("abc");  
-        dashInstance.setCachedUrls(["def"]);
-        remove.should.have.been.calledWith("abc");  
+      it('should remove asset urls that were initially added and are missing on a consecutive call', () => {
+        dashInstance.setCachedUrls(['abc']);
+        add.should.have.been.calledWith('abc');
+        dashInstance.setCachedUrls(['def']);
+        remove.should.have.been.calledWith('abc');
       });
 
-      it("should remove all asset urls when receiving an empty array on a consecutive call", () => {
+      it('should remove all asset urls when receiving an empty array on a consecutive call', () => {
         dashInstance.assetCache.list().length.should.equal(0);
-        dashInstance.setCachedUrls(["abc"]);
-        add.should.have.been.calledWith("abc");
-        dashInstance.setCachedUrls(["def"]);
-        add.should.have.been.calledWith("def");
+        dashInstance.setCachedUrls(['abc']);
+        add.should.have.been.calledWith('abc');
+        dashInstance.setCachedUrls(['def']);
+        add.should.have.been.calledWith('def');
         dashInstance.setCachedUrls([]);
-        remove.should.have.been.calledWith("abc");
-        remove.should.have.been.calledWith("def");
-      }); 
+        remove.should.have.been.calledWith('abc');
+        remove.should.have.been.calledWith('def');
+      });
     });
   });
 
@@ -2063,11 +2067,11 @@ describe('DashAdapter: setCachedUrls', () => {
     let get, load;
 
     beforeEach(() => {
-      get = sandbox.stub(dashInstance.assetCache, "get");
-      load = sandbox.stub(dashInstance.shaka, "load").resolves({});
+      get = sandbox.stub(dashInstance.assetCache, 'get');
+      load = sandbox.stub(dashInstance.shaka, 'load').resolves({});
     });
 
-    it("should check if url is cached", done => {
+    it('should check if url is cached', done => {
       dashInstance.load().then(() => {
         get.should.have.been.calledOnceWith(vodSource.url);
         load.should.have.been.calledOnceWith(vodSource.url, undefined);
@@ -2076,10 +2080,10 @@ describe('DashAdapter: setCachedUrls', () => {
     });
 
     it('should use cached url if url is cached', done => {
-      get.resolves("abc");
+      get.resolves('abc');
       dashInstance.setCachedUrls([vodSource.url]);
       dashInstance.load().then(() => {
-        load.should.have.been.calledWith("abc", undefined);
+        load.should.have.been.calledWith('abc', undefined);
         done();
       })
     });

--- a/tests/src/dash-adapter.spec.js
+++ b/tests/src/dash-adapter.spec.js
@@ -200,7 +200,7 @@ describe('DashAdapter: load', () => {
       .load()
       .then(() => {
         try {
-          dashInstance._shaka.should.exist;
+          dashInstance.shaka.should.exist;
           dashInstance._config.should.exist;
           dashInstance._videoElement.should.exist;
           dashInstance._sourceObj.should.exist;
@@ -218,7 +218,7 @@ describe('DashAdapter: load', () => {
     try {
       dashInstance = DashAdapter.createAdapter(video, vodSource, config);
       video.addEventListener(EventType.LOADED_DATA, () => {
-        dashInstance._shaka.getConfiguration().streaming.lowLatencyMode.should.equal(false);
+        dashInstance.shaka.getConfiguration().streaming.lowLatencyMode.should.equal(false);
         done();
       });
 
@@ -234,7 +234,7 @@ describe('DashAdapter: load', () => {
     try {
       dashInstance = DashAdapter.createAdapter(video, liveSource, config);
       video.addEventListener(EventType.LOADED_DATA, () => {
-        dashInstance._shaka.getConfiguration().streaming.lowLatencyMode.should.equal(true);
+        dashInstance.shaka.getConfiguration().streaming.lowLatencyMode.should.equal(true);
         done();
       });
 
@@ -251,7 +251,7 @@ describe('DashAdapter: load', () => {
       const playerConfig = {...config, streaming: {lowLatencyMode: true}};
       dashInstance = DashAdapter.createAdapter(video, vodSource, playerConfig);
       video.addEventListener(EventType.LOADED_DATA, () => {
-        dashInstance._shaka.getConfiguration().streaming.lowLatencyMode.should.equal(true);
+        dashInstance.shaka.getConfiguration().streaming.lowLatencyMode.should.equal(true);
         done();
       });
 
@@ -268,7 +268,7 @@ describe('DashAdapter: load', () => {
       const playerConfig = {...config, streaming: {lowLatencyMode: false}};
       dashInstance = DashAdapter.createAdapter(video, vodSource, playerConfig);
       video.addEventListener(EventType.LOADED_DATA, () => {
-        dashInstance._shaka.getConfiguration().streaming.lowLatencyMode.should.equal(false);
+        dashInstance.shaka.getConfiguration().streaming.lowLatencyMode.should.equal(false);
         done();
       });
 
@@ -369,8 +369,8 @@ describe('DashAdapter: targetBuffer', () => {
       dashInstance = DashAdapter.createAdapter(video, vodSource, config);
       video.addEventListener(EventType.PLAYING, () => {
         const targetBufferVal =
-          dashInstance._shaka.getConfiguration().streaming.bufferingGoal +
-          dashInstance._shaka.getManifest().presentationTimeline.getMaxSegmentDuration();
+          dashInstance.shaka.getConfiguration().streaming.bufferingGoal +
+          dashInstance.shaka.getManifest().presentationTimeline.getMaxSegmentDuration();
         Math.round(dashInstance.targetBuffer - targetBufferVal).should.equal(0);
 
         done();
@@ -531,7 +531,7 @@ describe('DashAdapter: _getParsedTracks', () => {
       .then(data => {
         let videoTracks = dashInstance._getVideoTracks();
         let audioTracks = dashInstance._getAudioTracks();
-        let textTracks = dashInstance._shaka.getTextTracks();
+        let textTracks = dashInstance.shaka.getTextTracks();
         let totalTracksLength = videoTracks.length + audioTracks.length + textTracks.length;
         try {
           data.tracks.length.should.be.equal(totalTracksLength);
@@ -922,7 +922,7 @@ describe('DashAdapter: selectTextTrack', () => {
         return !track.active;
       })[0];
       dashInstance.selectTextTrack(inactiveTrack);
-      let activeTrack = dashInstance._shaka.getTextTracks().filter(track => {
+      let activeTrack = dashInstance.shaka.getTextTracks().filter(track => {
         return track.active;
       })[0];
       activeTrack.language.should.be.equal(inactiveTrack.language);
@@ -940,7 +940,7 @@ describe('DashAdapter: selectTextTrack', () => {
       dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack(activeTrack);
       activeTrack.language.should.be.equal(
-        dashInstance._shaka.getTextTracks().filter(track => {
+        dashInstance.shaka.getTextTracks().filter(track => {
           return track.active;
         })[0].language
       );
@@ -962,7 +962,7 @@ describe('DashAdapter: selectTextTrack', () => {
       dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack(new VideoTrack({index: 0}));
       activeTrack.language.should.be.equal(
-        dashInstance._shaka.getTextTracks().filter(track => {
+        dashInstance.shaka.getTextTracks().filter(track => {
           return track.active;
         })[0].language
       );
@@ -984,7 +984,7 @@ describe('DashAdapter: selectTextTrack', () => {
       dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack();
       activeTrack.language.should.be.equal(
-        dashInstance._shaka.getTextTracks().filter(track => {
+        dashInstance.shaka.getTextTracks().filter(track => {
           return track.active;
         })[0].language
       );
@@ -1006,7 +1006,7 @@ describe('DashAdapter: selectTextTrack', () => {
       dashInstance.selectTextTrack(activeTrack);
       dashInstance.selectTextTrack(new TextTrack({kind: 'metadata'}));
       activeTrack.language.should.be.equal(
-        dashInstance._shaka.getTextTracks().filter(track => {
+        dashInstance.shaka.getTextTracks().filter(track => {
           return track.active;
         })[0].language
       );
@@ -1042,9 +1042,9 @@ describe('DashAdapter: enableAdaptiveBitrate', () => {
     dashInstance
       .load()
       .then(() => {
-        dashInstance._shaka.getConfiguration().abr.enabled.should.be.false;
+        dashInstance.shaka.getConfiguration().abr.enabled.should.be.false;
         dashInstance.enableAdaptiveBitrate();
-        dashInstance._shaka.getConfiguration().abr.enabled.should.be.true;
+        dashInstance.shaka.getConfiguration().abr.enabled.should.be.true;
         dashInstance.isAdaptiveBitrateEnabled().should.be.true;
         done();
       })
@@ -1176,7 +1176,7 @@ describe('DashAdapter: _getLiveEdge', () => {
       .load()
       .then(() => {
         try {
-          Math.floor(Math.abs(dashInstance._getLiveEdge() - dashInstance._shaka.seekRange().end)).should.equal(0);
+          Math.floor(Math.abs(dashInstance._getLiveEdge() - dashInstance.shaka.seekRange().end)).should.equal(0);
           done();
         } catch (e) {
           done(e);
@@ -1214,10 +1214,10 @@ describe('DashAdapter: seekToLiveEdge', () => {
       .then(() => {
         try {
           video.play().then(() => {
-            video.currentTime = dashInstance._shaka.seekRange().start;
-            const initialTimeShift = dashInstance._shaka.seekRange().end - video.currentTime;
+            video.currentTime = dashInstance.shaka.seekRange().start;
+            const initialTimeShift = dashInstance.shaka.seekRange().end - video.currentTime;
             dashInstance.seekToLiveEdge();
-            const timeShift = dashInstance._shaka.seekRange().end - video.currentTime;
+            const timeShift = dashInstance.shaka.seekRange().end - video.currentTime;
             timeShift.should.be.lessThan(3);
             timeShift.should.be.lessThan(initialTimeShift);
             done();
@@ -1237,10 +1237,10 @@ describe('DashAdapter: seekToLiveEdge', () => {
       .load()
       .then(() => {
         try {
-          video.currentTime = dashInstance._shaka.seekRange().start;
-          (dashInstance._shaka.seekRange().end - video.currentTime > 30).should.be.true;
+          video.currentTime = dashInstance.shaka.seekRange().start;
+          (dashInstance.shaka.seekRange().end - video.currentTime > 30).should.be.true;
           dashInstance.seekToLiveEdge();
-          (dashInstance._shaka.seekRange().end - video.currentTime < 1).should.be.true;
+          (dashInstance.shaka.seekRange().end - video.currentTime < 1).should.be.true;
           done();
         } catch (e) {
           done(e);
@@ -1422,7 +1422,7 @@ describe('DashAdapter: getStartTimeOfDvrWindow', () => {
       setTimeout(() => {
         try {
           Math.floor(dashInstance.getStartTimeOfDvrWindow()).should.equal(
-            Math.floor(dashInstance._shaka.seekRange().start + dashInstance._shaka.getConfiguration().streaming.safeSeekOffset)
+            Math.floor(dashInstance.shaka.seekRange().start + dashInstance.shaka.getConfiguration().streaming.safeSeekOffset)
           );
           done();
         } catch (e) {
@@ -1852,7 +1852,7 @@ describe('DashAdapter: in-stream thumbnails', () => {
       .load()
       .then(result => {
         try {
-          dashInstance._shaka.should.exist;
+          dashInstance.shaka.should.exist;
           dashInstance._config.should.exist;
           dashInstance._videoElement.should.exist;
           dashInstance._sourceObj.should.exist;
@@ -1878,7 +1878,7 @@ describe('DashAdapter: in-stream thumbnails', () => {
       .load()
       .then(result => {
         try {
-          dashInstance._shaka.should.exist;
+          dashInstance.shaka.should.exist;
           dashInstance._config.should.exist;
           dashInstance._videoElement.should.exist;
           dashInstance._sourceObj.should.exist;

--- a/tests/src/dash-adapter.spec.js
+++ b/tests/src/dash-adapter.spec.js
@@ -7,6 +7,7 @@ import {wwDrmData, prDrmData} from './drm/fake-drm-data';
 import shaka from 'shaka-player';
 import {ImageTrack, ThumbnailInfo} from '@playkit-js/playkit-js';
 import { expect } from 'chai';
+import sinonChai from 'sinon-chai';
 
 const targetId = 'player-placeholder_dash-adapter.spec';
 
@@ -2025,25 +2026,36 @@ describe('DashAdapter: setCachedUrls', () => {
         remove = sandbox.stub(dashInstance.assetCache, "remove");
       });
 
-      it("should not add the same url twice on consecutive calls", () => {
+      it("should not add the same url twice on a consecutive call", () => {
         dashInstance.setCachedUrls(["abc"]);
         dashInstance.setCachedUrls(["abc"]);
         add.should.have.been.calledOnceWith("abc");   
       });
 
-      it("should add new urls on consecutive calls", () => {
+      it("should add new urls on a consecutive call", () => {
         dashInstance.setCachedUrls(["abc"]);
         add.should.have.been.calledWith("abc");  
         dashInstance.setCachedUrls(["abc", "def"]);
         add.should.have.been.calledWith("def");  
       });
 
-      it("should remove asset urls that were initially added and are missing on consecutive calls", () => {
+      it("should remove asset urls that were initially added and are missing on a consecutive call", () => {
         dashInstance.setCachedUrls(["abc"]);
         add.should.have.been.calledWith("abc");  
         dashInstance.setCachedUrls(["def"]);
         remove.should.have.been.calledWith("abc");  
       });
+
+      it("should remove all asset urls when receiving an empty array on a consecutive call", () => {
+        dashInstance.assetCache.list().length.should.equal(0);
+        dashInstance.setCachedUrls(["abc"]);
+        add.should.have.been.calledWith("abc");
+        dashInstance.setCachedUrls(["def"]);
+        add.should.have.been.calledWith("def");
+        dashInstance.setCachedUrls([]);
+        remove.should.have.been.calledWith("abc");
+        remove.should.have.been.calledWith("def");
+      }); 
     });
   });
 

--- a/tests/src/dash-adapter.spec.js
+++ b/tests/src/dash-adapter.spec.js
@@ -498,6 +498,22 @@ describe('DashAdapter: destroy', () => {
         done(e);
       });
   });
+
+  it('should destroy shaka instance if there are no cached urls', done => {
+    const destroy = sinon.spy(dashInstance.shaka, "destroy");
+    dashInstance.destroy().then(() => {
+      destroy.should.have.been.calledOnce;
+      done();
+    });
+  });
+  it('should not destroy shaka instance if there are cached urls', done => {
+    const destroy = sinon.spy(dashInstance.shaka, "destroy");
+    dashInstance.setCachedUrls(["abc"]);
+    dashInstance.destroy().then(() => {
+      destroy.should.not.have.been.called;
+      done();
+    })
+  });
 });
 
 describe('DashAdapter: _getParsedTracks', () => {

--- a/tests/src/utils/test-utils.js
+++ b/tests/src/utils/test-utils.js
@@ -6,12 +6,12 @@
  * @returns {HTMLDivElement}
  */
 function createElement(type, id, opt_parentId) {
-  let element = document.createElement(type);
+  const element = document.createElement(type);
   element.id = id;
   if (!opt_parentId) {
     document.body.appendChild(element);
   } else {
-    let parent = document.getElementById(opt_parentId);
+    const parent = document.getElementById(opt_parentId);
     if (parent) {
       parent.appendChild(element);
     } else {
@@ -27,7 +27,7 @@ function createElement(type, id, opt_parentId) {
  * @returns {void}
  */
 function removeElement(id) {
-  let element = document.getElementById(id);
+  const element = document.getElementById(id);
   element.parentNode.removeChild(element);
 }
 
@@ -36,7 +36,7 @@ function removeElement(id) {
  * @returns {void}
  */
 function removeVideoElementsFromTestPage() {
-  let element = document.getElementsByTagName('video');
+  const element = document.getElementsByTagName('video');
   for (let i = element.length - 1; i >= 0; i--) {
     element[i].parentNode.removeChild(element[i]);
   }
@@ -48,8 +48,8 @@ function removeVideoElementsFromTestPage() {
  * @returns {void}
  */
 function createTitle(title) {
-  let header = document.createElement('header');
-  let h4 = document.createElement('h4');
+  const header = document.createElement('header');
+  const h4 = document.createElement('h4');
   h4.textContent = title;
   header.appendChild(h4);
   document.body.appendChild(header);
@@ -62,7 +62,7 @@ function createTitle(title) {
  * @returns {Element} - The track button element.
  */
 function createTrackButton(innerText, id) {
-  let element = document.createElement('BUTTON');
+  const element = document.createElement('BUTTON');
   element.innerText = innerText;
   element.id = id;
   document.body.appendChild(element);
@@ -78,7 +78,7 @@ function createTrackButton(innerText, id) {
 function createVideoTrackButtons(player, videoTracks) {
   createTitle('Video Tracks');
   for (let i = 0; i < videoTracks.length; i++) {
-    let element = createTrackButton(videoTracks[i].label || videoTracks[i].bandwidth || videoTracks[i].language, videoTracks[i].index);
+    const element = createTrackButton(videoTracks[i].label || videoTracks[i].bandwidth || videoTracks[i].language, videoTracks[i].index);
     element.onclick = function () {
       player.selectTrack(videoTracks[i]);
     };
@@ -94,7 +94,7 @@ function createVideoTrackButtons(player, videoTracks) {
 function createAudioTrackButtons(player, audioTracks) {
   createTitle('Audio Tracks');
   for (let i = 0; i < audioTracks.length; i++) {
-    let element = createTrackButton(audioTracks[i].label || audioTracks[i].language, audioTracks[i].index);
+    const element = createTrackButton(audioTracks[i].label || audioTracks[i].language, audioTracks[i].index);
     element.onclick = function () {
       player.selectTrack(audioTracks[i]);
     };
@@ -110,7 +110,7 @@ function createAudioTrackButtons(player, audioTracks) {
 function createTextTrackButtons(player, textTracks) {
   createTitle('Text Tracks');
   for (let i = 0; i < textTracks.length; i++) {
-    let element = createTrackButton(textTracks[i].label || textTracks[i].language, textTracks[i].index);
+    const element = createTrackButton(textTracks[i].label || textTracks[i].language, textTracks[i].index);
     element.onclick = function () {
       player.selectTrack(textTracks[i]);
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5534,10 +5534,10 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shaka-player@4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.7.0.tgz#5bb0a60c1b7c2a8a3c2d1ff82e632c3c000219c3"
-  integrity sha512-utR9hKMt8GiGv7EDC8/nh8F1c4KeVGa4Wd8k6h+g2Ylks0m9//kvxvXkQnYAGJRtdql/CJC9Ur8YQ/G+kTwoiQ==
+shaka-player@4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.8.4.tgz#dee88b29122da78aee02e6ce6ca76ff6c17435ab"
+  integrity sha512-LtPUioN0/kwLi5ewSFaoSUpQgA01XxaSa7vneCiXP8AMIdIWVM+pk/lFetwW0br26H8Lb79djiU+5vhJujEBjQ==
   dependencies:
     eme-encryption-scheme-polyfill "^2.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5534,10 +5534,10 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shaka-player@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.8.4.tgz#dee88b29122da78aee02e6ce6ca76ff6c17435ab"
-  integrity sha512-LtPUioN0/kwLi5ewSFaoSUpQgA01XxaSa7vneCiXP8AMIdIWVM+pk/lFetwW0br26H8Lb79djiU+5vhJujEBjQ==
+shaka-player@4.8.11:
+  version "4.8.11"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.8.11.tgz#f67df889ac859875a2f53645840c39b67b568192"
+  integrity sha512-PXrizP6bWi6Gzjk5B7aSfBiU81di1kPd8LEBIzdaNvwINjZSMYL+lDzEWeLTIoyZCjb3l1WoJJTGLex8mD3dmg==
   dependencies:
     eme-encryption-scheme-polyfill "^2.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,10 +1175,10 @@
   resolved "https://registry.yarnpkg.com/@playkit-js/browserslist-config/-/browserslist-config-1.0.8.tgz#735256ba560063d397d4b8776acb865e8697a287"
   integrity sha512-BeiDM72c6GP8dZ6b2qScEpxT4sGECIJzjVGsanaTvXeFOkw3MoplAyz6HPKdrcLmidcinSl4yna5Yc9/ObwZow==
 
-"@playkit-js/playkit-js@canary":
-  version "0.84.2-canary.0-cceb0c7"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.2-canary.0-cceb0c7.tgz#a3b47545b2710acaf55811f48115bb75b8ff7972"
-  integrity sha512-pa2JDuNA1MD5cxYLT65GXVw8SLgL1QuTyklT88cxHa4Ir7XMbWJBV+1lp9RS363jNX1+pgMQT5lCWthEb8pqXg==
+"@playkit-js/playkit-js@0.84.10-canary.0-fa40833":
+  version "0.84.10-canary.0-fa40833"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.10-canary.0-fa40833.tgz#15a2e7a2927b81f62d292753250d48f3c6af1365"
+  integrity sha512-qDaZWIz363kScuBjhg9P3zc2dG0yewQ5vj/+XsJYJMtIycE1WThhPi1gX/3AG/uBf/5oABYjq2Fi2AoQbRfvSA==
   dependencies:
     js-logger "^1.6.0"
     ua-parser-js "^1.0.36"


### PR DESCRIPTION
### Description of the Changes

- Update shaka to version which has the new preload API + preload bug fixes
- Use shaka preload API and save the result (preloadManager instance) in a cache
- If we try to load a manifest url and it has been previously cached, shaka instance load() will accept the preloadManager instead of the manifest url. This results in a shortened load time.

preloadManager instances only work with the shaka player that they were created by, which required the following changes:
- Instead of having one instance of shaka per adapter we now have one shared instance per player (mapped by video element id)
- Destroying a shaka instance invalidates its preloadManagers and also renders it unusable (forcing creation of a new instance) so it can only be destroyed if it has no preloadManagers
- On destroy, if the cache is EMPTY, the instance will be destroyed and later it will be recreated on the next call to _init
- If the cache is NOT EMPTY, the shaka instance will be detached instead of destroyed

- Add adapter setCachedUrls API which adds / removes items from the cache 
- Update tests and add new tests to cover the setCachedUrls API

Related PRs:
https://github.com/kaltura/playkit-js/pull/780
https://github.com/kaltura/kaltura-player-js/pull/792

Resolves FEC-13946
