### PR TITLE
fix(SUP-46763): [PPF]-RS(3200)-SK(3206) : [Web]: TwS are not displayed on end device on channel with catchup and blackout enabled

### DIFF
--- a/src/dash-thumbnail-controller.ts
+++ b/src/dash-thumbnail-controller.ts
@@ -89,7 +89,7 @@ class DashThumbnailController {
   private _buildTemplateUrl = (mediaTemplate: string, id: string, url: string, mediaTemplatePrefix: string): string => {
     const last = url.split('/').pop()!;
     const baseUrl = url.replace(last, '');
-    const regex = /^\.\/|^\./;
+    const regex = /^\.\//;
     mediaTemplatePrefix = mediaTemplatePrefix.replace(regex, '');
     if (mediaTemplatePrefix.length > 0 && !mediaTemplatePrefix.endsWith('/')) {
       mediaTemplatePrefix += '/';


### PR DESCRIPTION
ISSUE:
when broadpeak enabled with blackout thumbnails are not show and return an error

rootcause:
the player get url with template like "../.." in case it start with "./" there was a regex to remove it, hoever the regex was wrong and remove any "." at start

fix:
change the regex to remove only "./"

solve [SUP-46763](https://kaltura.atlassian.net/browse/SUP-46763)


[SUP-46763]: https://kaltura.atlassian.net/browse/SUP-46763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ