### PR TITLE
feat(FEC-14419): Expose Accessibility Audio \ Text Track Indications

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "shaka-player": "4.7.0",
     "sinon": "^14.0.0",
     "sinon-chai": "^3.7.0",
+    "source-map-loader": "^5.0.0",
     "standard-version": "^6.0.1",
     "style-loader": "^3.3.3",
     "typescript": "^5.2.2",

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -1017,7 +1017,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     const variantTracks = this._shaka.getVariantTracks();
     const audioTracks = this._shaka.getAudioLanguagesAndRoles();
     audioTracks.forEach(track => {
-      const sameLangAudioVariants = variantTracks.filter(vt => vt.language === track.language && vt.audioRoles?.includes(track.role));
+      const sameLangAudioVariants = variantTracks.filter(vt => vt.language === track.language && (!track.role || vt.audioRoles?.includes(track.role)));
       const id = sameLangAudioVariants.map(variant => variant.id).join('_');
       const active = sameLangAudioVariants.some(variant => variant.active);
       const isAccessible = sameLangAudioVariants.some(variant => variant.accessibilityPurpose);

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -1017,7 +1017,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     const variantTracks = this._shaka.getVariantTracks();
     const audioTracks = this._shaka.getAudioLanguagesAndRoles();
     audioTracks.forEach(track => {
-      const sameLangAudioVariants = variantTracks.filter(vt => vt.language === track.language && (!track.role || vt.audioRoles?.includes(track.role)));
+      const sameLangAudioVariants = variantTracks.filter(vt => vt.language === track.language && (!track.role || !vt.audioRoles || vt.audioRoles.includes(track.role)));
       const id = sameLangAudioVariants.map(variant => variant.id).join('_');
       const active = sameLangAudioVariants.some(variant => variant.active);
       const isAccessible = sameLangAudioVariants.some(variant => variant.accessibilityPurpose);

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -14,6 +14,7 @@ import {
   ImageTrack,
   ThumbnailInfo,
   PKABRRestrictionObject,
+  AudioTrackKind,
   filterTracksByRestriction, PKDrmDataObject, PKMediaSourceObject, IMediaSourceAdapter, FakeEvent, IDrmProtocol, PKResponseObject, PKRequestObject, PKDrmConfigObject
 } from '@playkit-js/playkit-js';
 import {Widevine} from './drm/widevine';
@@ -39,6 +40,8 @@ const ShakaEvent: ShakaEventType = {
 };
 
 type ErrorEventsType = {[errorCode: string]: {'timeStamp': number, 'count': number}};
+
+type ShakaAudioTrack = shaka.extern.LanguageRole & { active: boolean, id: number, kind: string };
 
 
 /**
@@ -1010,18 +1013,20 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    * @returns {Array<Object>} - Array of objects with unique language and label.
    * @private
    */
-  private _getAudioTracks(): (shaka.extern.LanguageRole & { active: boolean, id: number })[] {
+  private _getAudioTracks(): ShakaAudioTrack[] {
     const variantTracks = this._shaka.getVariantTracks();
     const audioTracks = this._shaka.getAudioLanguagesAndRoles();
     audioTracks.forEach(track => {
-      const sameLangAudioVariants = variantTracks.filter(vt => vt.language === track.language);
+      const sameLangAudioVariants = variantTracks.filter(vt => vt.language === track.language && vt.audioRoles?.includes(track.role));
       const id = sameLangAudioVariants.map(variant => variant.id).join('_');
       const active = sameLangAudioVariants.some(variant => variant.active);
+      const isAccessible = sameLangAudioVariants.some(variant => variant.accessibilityPurpose);
       track['id'] = id;
       track.label = sameLangAudioVariants[0].label;
       track['active'] = active;
+      track['kind'] =  isAccessible ? AudioTrackKind.DESCRIPTION : AudioTrackKind.MAIN;
     });
-    return audioTracks as (shaka.extern.LanguageRole & { active: boolean, id: number })[];
+    return audioTracks as ShakaAudioTrack[];
   }
 
   /**
@@ -1082,7 +1087,8 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
           active: audioTracks[i].active,
           label: audioTracks[i].label,
           language: audioTracks[i].language,
-          index: i
+          index: i,
+          kind: audioTracks[i].kind
         };
         parsedTracks.push(new AudioTrack(settings));
       }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,11 @@ module.exports = (env, { mode }) => {
     module: {
       rules: [
         {
+          test: /\.js$/,
+          enforce: 'pre',
+          use: ['source-map-loader'],
+        },
+        {
           test: /\.(ts|js)$/,
           exclude: /node_modules/,
           use: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,7 @@ module.exports = (env, { mode }) => {
       '@playkit-js/playkit-js': {
         commonjs: '@playkit-js/playkit-js',
         commonjs2: '@playkit-js/playkit-js',
-        amd: 'playkit-js',
+        amd: '@playkit-js/playkit-js',
         root: ['playkit', 'core']
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,6 +3656,13 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
@@ -5400,7 +5407,7 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -5665,6 +5672,14 @@ source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
+source-map-loader@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-5.0.0.tgz#f593a916e1cc54471cfc8851b905c8a845fc7e38"
+  integrity sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==
+  dependencies:
+    iconv-lite "^0.6.3"
+    source-map-js "^1.0.2"
 
 source-map-support@~0.5.20:
   version "0.5.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,10 +1176,11 @@
   integrity sha512-BeiDM72c6GP8dZ6b2qScEpxT4sGECIJzjVGsanaTvXeFOkw3MoplAyz6HPKdrcLmidcinSl4yna5Yc9/ObwZow==
 
 "@playkit-js/playkit-js@canary":
-  version "0.84.2-canary.0-cceb0c7"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.2-canary.0-cceb0c7.tgz#a3b47545b2710acaf55811f48115bb75b8ff7972"
-  integrity sha512-pa2JDuNA1MD5cxYLT65GXVw8SLgL1QuTyklT88cxHa4Ir7XMbWJBV+1lp9RS363jNX1+pgMQT5lCWthEb8pqXg==
+  version "0.84.27-canary.0-ea430f6"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.27-canary.0-ea430f6.tgz#43b2454d4d36564c63833f233aafd3772a6e0e91"
+  integrity sha512-h5XVXlZ39osMcbpPsuRnwTojmfx6DvE+qHa0tIDfF4xibL4NJdWECXy7ygunCCAxUcMmCco4nkxA8J0NFhZC0g==
   dependencies:
+    "@playkit-js/webpack-common" "^1.0.3"
     js-logger "^1.6.0"
     ua-parser-js "^1.0.36"
 


### PR DESCRIPTION
### Description of the Changes

enhancement.

**Requirement:**
The requirement is to expose `kind` field for audio and text tracks according to accessibility parameters.
- audio tracks: possible values: `main`, `description` 
- text tracks: possible values: `subtitles`, `captions`

**Changes in this PR:**
for audio tracks:
- filter `sameLangAudioVariants` also by `role` field to distinguish between a11y audio stream and regular one
- check if the audio stream is accessible according to `accessibilityPurpose` field
- add `kind` field to `audioTracks` parsed in dash-adapter

for text tracks:
- `kind` field already exists on `textTracks` in dash-adapter

also fix the playkit-js dep in webpack file.

**depends on** [PR](https://github.com/kaltura/playkit-js/pull/815)

### Resolves FEC-14419
