### PR TITLE
fix(SUP-51711): Audio Description Language selection not working as expected in some browsers

### DIFF
--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -1186,7 +1186,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   public selectAudioTrack(audioTrack: AudioTrack): void {
     if (this._shaka && audioTrack instanceof AudioTrack && !audioTrack.active) {
-      this._shaka.selectAudioLanguage(audioTrack.language);
+      this._shaka.selectAudioLanguage(audioTrack.language, undefined, undefined, undefined, undefined, undefined, audioTrack.label);
       this._onTrackChanged(audioTrack);
     }
   }


### PR DESCRIPTION
### Description of the Changes

Continuation of https://github.com/kaltura/playkit-js-dash/pull/271
When changing audio track, use audio label (display name) to distinguish between audio tracks with the same language (short name)

Resolves [SUP-51711](https://kaltura.atlassian.net/browse/SUP-51711)


[SUP-51711]: https://kaltura.atlassian.net/browse/SUP-51711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ