### PR TITLE
feat(FEC-15007): Live streaming: report primary vs secondary stream dimension to Kava on live playback events

### DIFF
--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -797,15 +797,15 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       case shaka.net.NetworkingEngine.RequestType.MANIFEST:
         this._parseManifest(response.data);
         this._playbackActualUri = response.uri;
-        if (!this._liveEntryStValue) {
-          this._liveEntryStValue = response.uri?.match(/\/st\/([01])\//)?.[1] ?? '';
-        }
         this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
         setTimeout(() => {
           this._isLive = this._isLive || this._shaka?.isLive() as boolean;
           if (this._isLive && !this._shaka?.isLive() && !this._isStaticLive && this._config.switchDynamicToStatic) {
               this._sourceObj!.url = response.uri;
               this._switchFromDynamicToStatic();
+          }
+          if (this._isLive && !this._liveEntryStValue) {
+            this._liveEntryStValue = response.uri?.match(/\/st\/([01])\//)?.[1] ?? '';
           }
         });
         break;

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -241,6 +241,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
   private _isStaticLive: boolean = false;
   private _selectedVideoTrack: VideoTrack | undefined | null = null;
   private _playbackActualUri: string | undefined;
+  private _liveEntryStValue: string = '';
 
   public applyTextTrackStyles(sheet: CSSStyleSheet, styles: any, containerId: string): void {
     const flexAlignment = {
@@ -796,6 +797,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       case shaka.net.NetworkingEngine.RequestType.MANIFEST:
         this._parseManifest(response.data);
         this._playbackActualUri = response.uri;
+        this._liveEntryStValue = response.uri?.match(/\/st\/([01])\//)?.[1] ?? '';
         this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
         setTimeout(() => {
           this._isLive = this._isLive || this._shaka?.isLive() as boolean;
@@ -1319,6 +1321,15 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
    */
   public isLive(): boolean {
     return this._shaka?.isLive() || this._isLive;
+  }
+
+  /**
+   * Returns extracted st value only for live entries.
+   * @returns {string} - st value for live entry, otherwise empty string.
+   * @public
+   */
+  public getLiveEntryStValue(): string {
+    return this._liveEntryStValue;
   }
 
   /**

--- a/src/dash-adapter.ts
+++ b/src/dash-adapter.ts
@@ -797,7 +797,9 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
       case shaka.net.NetworkingEngine.RequestType.MANIFEST:
         this._parseManifest(response.data);
         this._playbackActualUri = response.uri;
-        this._liveEntryStValue = response.uri?.match(/\/st\/([01])\//)?.[1] ?? '';
+        if (!this._liveEntryStValue) {
+          this._liveEntryStValue = response.uri?.match(/\/st\/([01])\//)?.[1] ?? '';
+        }
         this._trigger(EventType.MANIFEST_LOADED, {miliSeconds: response.timeMs});
         setTimeout(() => {
           this._isLive = this._isLive || this._shaka?.isLive() as boolean;
@@ -964,6 +966,7 @@ export default class DashAdapter extends BaseMediaSourceAdapter {
     this._responseFilterError = false;
     this._manifestParser = null;
     this._thumbnailController = null;
+    this._liveEntryStValue = '';
     this._errorCounter = {};
     this._clearStallInterval();
     this._clearVideoUpdateTimer();


### PR DESCRIPTION
### Description of the Changes

Adding getLiveEntryStValue function to extract live stream type from the manifest response.

related pr: https://github.com/kaltura/kaltura-player-js/pull/1247, https://github.com/kaltura/playkit-js-kava/pull/224, https://github.com/kaltura/playkit-js/pull/889, https://github.com/kaltura/playkit-js-hls/pull/247

**Resolves** [FEC-15007](https://kaltura.atlassian.net/browse/FEC-15007)


[FEC-15007]: https://kaltura.atlassian.net/browse/FEC-15007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ